### PR TITLE
Changes buildContext to be passed to contructor of Driver

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 BMW Technology Corporation
+Copyright (c) 2022 BMW Group AG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/widget_driver/example/lib/services/coffee_service.dart
+++ b/widget_driver/example/lib/services/coffee_service.dart
@@ -13,20 +13,26 @@ class CoffeeService {
 
   Future<List<Coffee>> getAllCoffees() async {
     _isFetchingStreamController.add(true);
+    try {
+      final response = await http.get(Uri.parse('https://api.sampleapis.com/coffee/hot')).timeout(
+            const Duration(seconds: 5),
+          );
 
-    final response = await http.get(Uri.parse('https://api.sampleapis.com/coffee/hot'));
-
-    if (response.statusCode == 200) {
-      Iterable iterable = json.decode(response.body);
-      _coffeeList = List<Coffee>.from(iterable.map((itemJson) => Coffee.fromJson(itemJson)));
-      _coffeeList.retainWhere((coffee) {
-        // Only keep coffees with valid imageUrl
-        final uri = Uri.parse(coffee.imageUrl);
-        return uri.hasScheme;
-      });
-    } else {
+      if (response.statusCode == 200) {
+        Iterable iterable = json.decode(response.body);
+        _coffeeList = List<Coffee>.from(iterable.map((itemJson) => Coffee.fromJson(itemJson)));
+        _coffeeList.retainWhere((coffee) {
+          // Only keep coffees with valid imageUrl
+          final uri = Uri.parse(coffee.imageUrl);
+          return uri.hasScheme;
+        });
+      } else {
+        // ignore: avoid_print
+        print('Failed to fetch coffees');
+      }
+    } catch (error) {
       // ignore: avoid_print
-      print('Failed to fetch coffees');
+      print('Failed to fetch coffees with error: $error');
     }
 
     _isFetchingStreamController.add(false);

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.dart
@@ -8,12 +8,12 @@ part 'coffee_community_page_driver.g.dart';
 
 @Driver()
 class CoffeeCommunityPageDriver extends WidgetDriver {
-  late AuthService _authService;
+  final AuthService _authService;
   StreamSubscription? _subscription;
 
-  @override
-  void setUpFromBuildContext(BuildContext context) {
-    _authService = context.read<AuthService>();
+  CoffeeCommunityPageDriver(BuildContext context)
+      : _authService = context.read<AuthService>(),
+        super(context) {
     _subscription = _authService.isLoggedInStream.listen((_) {
       notifyWidget();
     });

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
@@ -6,6 +6,16 @@ part of 'coffee_community_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
+/// You can use this typedef as a base class for your DrivableWidget
+///
+/// ```dart
+/// class MyCustomWidget extends $CoffeeCommunityPageDrivableWidget {
+///     ...
+/// }
+/// ```
+typedef $CoffeeCommunityPageDrivableWidget = DrivableWidget<
+    CoffeeCommunityPageDriver, $CoffeeCommunityPageDriverProvider>;
+
 class _$TestCoffeeCommunityPageDriver extends TestDriver
     implements CoffeeCommunityPageDriver {
   @override
@@ -15,8 +25,8 @@ class _$TestCoffeeCommunityPageDriver extends TestDriver
 class $CoffeeCommunityPageDriverProvider
     extends WidgetDriverProvider<CoffeeCommunityPageDriver> {
   @override
-  CoffeeCommunityPageDriver buildDriver() {
-    return CoffeeCommunityPageDriver();
+  CoffeeCommunityPageDriver buildDriver(BuildContext context) {
+    return CoffeeCommunityPageDriver(context);
   }
 
   @override
@@ -24,6 +34,3 @@ class $CoffeeCommunityPageDriverProvider
     return _$TestCoffeeCommunityPageDriver();
   }
 }
-
-typedef $CoffeeCommunityPageDrivableWidget = DrivableWidget<
-    CoffeeCommunityPageDriver, $CoffeeCommunityPageDriverProvider>;

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.dart
@@ -7,12 +7,11 @@ part 'coffee_detail_page_driver.g.dart';
 
 @Driver()
 class CoffeeDetailPageDriver extends WidgetDriver {
-  late final Coffee _coffee;
+  final Coffee _coffee;
 
-  @override
-  void setUpFromBuildContext(BuildContext context) {
-    _coffee = context.read<Coffee>();
-  }
+  CoffeeDetailPageDriver(BuildContext context)
+      : _coffee = context.read<Coffee>(),
+        super(context);
 
   @DriverProperty(TestCoffee.testCoffeeName)
   String get coffeeName {

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
@@ -6,6 +6,16 @@ part of 'coffee_detail_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
+/// You can use this typedef as a base class for your DrivableWidget
+///
+/// ```dart
+/// class MyCustomWidget extends $CoffeeDetailPageDrivableWidget {
+///     ...
+/// }
+/// ```
+typedef $CoffeeDetailPageDrivableWidget
+    = DrivableWidget<CoffeeDetailPageDriver, $CoffeeDetailPageDriverProvider>;
+
 class _$TestCoffeeDetailPageDriver extends TestDriver
     implements CoffeeDetailPageDriver {
   @override
@@ -21,8 +31,8 @@ class _$TestCoffeeDetailPageDriver extends TestDriver
 class $CoffeeDetailPageDriverProvider
     extends WidgetDriverProvider<CoffeeDetailPageDriver> {
   @override
-  CoffeeDetailPageDriver buildDriver() {
-    return CoffeeDetailPageDriver();
+  CoffeeDetailPageDriver buildDriver(BuildContext context) {
+    return CoffeeDetailPageDriver(context);
   }
 
   @override
@@ -30,6 +40,3 @@ class $CoffeeDetailPageDriverProvider
     return _$TestCoffeeDetailPageDriver();
   }
 }
-
-typedef $CoffeeDetailPageDrivableWidget
-    = DrivableWidget<CoffeeDetailPageDriver, $CoffeeDetailPageDriverProvider>;

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.dart
@@ -15,9 +15,11 @@ class CoffeeLibraryPageDriver extends WidgetDriver {
   List<Coffee> _coffees = [];
   StreamSubscription? _subscription;
 
-  CoffeeLibraryPageDriver({
+  CoffeeLibraryPageDriver(
+    BuildContext context, {
     CoffeeService? coffeeService,
-  }) : _coffeeService = coffeeService ?? GetIt.I.get<CoffeeService>() {
+  })  : _coffeeService = coffeeService ?? GetIt.I.get<CoffeeService>(),
+        super(context) {
     _subscription = _coffeeService.isFetchingStream.listen((isFetching) {
       _isFetching = isFetching;
       notifyWidget();

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
@@ -6,6 +6,16 @@ part of 'coffee_library_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
+/// You can use this typedef as a base class for your DrivableWidget
+///
+/// ```dart
+/// class MyCustomWidget extends $CoffeeLibraryPageDrivableWidget {
+///     ...
+/// }
+/// ```
+typedef $CoffeeLibraryPageDrivableWidget
+    = DrivableWidget<CoffeeLibraryPageDriver, $CoffeeLibraryPageDriverProvider>;
+
 class _$TestCoffeeLibraryPageDriver extends TestDriver
     implements CoffeeLibraryPageDriver {
   @override
@@ -23,8 +33,8 @@ class _$TestCoffeeLibraryPageDriver extends TestDriver
 class $CoffeeLibraryPageDriverProvider
     extends WidgetDriverProvider<CoffeeLibraryPageDriver> {
   @override
-  CoffeeLibraryPageDriver buildDriver() {
-    return CoffeeLibraryPageDriver();
+  CoffeeLibraryPageDriver buildDriver(BuildContext context) {
+    return CoffeeLibraryPageDriver(context);
   }
 
   @override
@@ -32,6 +42,3 @@ class $CoffeeLibraryPageDriverProvider
     return _$TestCoffeeLibraryPageDriver();
   }
 }
-
-typedef $CoffeeLibraryPageDrivableWidget
-    = DrivableWidget<CoffeeLibraryPageDriver, $CoffeeLibraryPageDriverProvider>;

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.dart
@@ -7,12 +7,11 @@ part 'not_logged_in_page_driver.g.dart';
 
 @Driver()
 class NotLoggedInPageDriver extends WidgetDriver {
-  late final Localization _localization;
+  final Localization _localization;
 
-  @override
-  void setUpFromBuildContext(BuildContext context) {
-    _localization = context.read<Localization>();
-  }
+  NotLoggedInPageDriver(BuildContext context)
+      : _localization = context.read<Localization>(),
+        super(context);
 
   @DriverProperty('Not logged in')
   String get notLoggedInText => _localization.notLoggedIn;

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
@@ -6,6 +6,16 @@ part of 'not_logged_in_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
+/// You can use this typedef as a base class for your DrivableWidget
+///
+/// ```dart
+/// class MyCustomWidget extends $NotLoggedInPageDrivableWidget {
+///     ...
+/// }
+/// ```
+typedef $NotLoggedInPageDrivableWidget
+    = DrivableWidget<NotLoggedInPageDriver, $NotLoggedInPageDriverProvider>;
+
 class _$TestNotLoggedInPageDriver extends TestDriver
     implements NotLoggedInPageDriver {
   @override
@@ -15,8 +25,8 @@ class _$TestNotLoggedInPageDriver extends TestDriver
 class $NotLoggedInPageDriverProvider
     extends WidgetDriverProvider<NotLoggedInPageDriver> {
   @override
-  NotLoggedInPageDriver buildDriver() {
-    return NotLoggedInPageDriver();
+  NotLoggedInPageDriver buildDriver(BuildContext context) {
+    return NotLoggedInPageDriver(context);
   }
 
   @override
@@ -24,6 +34,3 @@ class $NotLoggedInPageDriverProvider
     return _$TestNotLoggedInPageDriver();
   }
 }
-
-typedef $NotLoggedInPageDrivableWidget
-    = DrivableWidget<NotLoggedInPageDriver, $NotLoggedInPageDriverProvider>;

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.dart
@@ -12,21 +12,19 @@ part 'coffee_counter_widget_driver.g.dart';
 @Driver()
 class CoffeeCounterWidgetDriver extends WidgetDriver {
   final CoffeeConsumptionService _consumptionService;
-  late final Localization _localization;
+  final Localization _localization;
 
   StreamSubscription? _subscription;
 
-  CoffeeCounterWidgetDriver({
+  CoffeeCounterWidgetDriver(
+    BuildContext context, {
     CoffeeConsumptionService? consumptionService,
-  }) : _consumptionService = consumptionService ?? GetIt.I.get<CoffeeConsumptionService>() {
+  })  : _consumptionService = consumptionService ?? GetIt.I.get<CoffeeConsumptionService>(),
+        _localization = context.read<Localization>(),
+        super(context) {
     _subscription = _consumptionService.counterStream.listen((event) {
       notifyWidget();
     });
-  }
-
-  @override
-  void setUpFromBuildContext(BuildContext context) {
-    _localization = context.read<Localization>();
   }
 
   @DriverProperty('Consumed coffees')

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
@@ -6,6 +6,16 @@ part of 'coffee_counter_widget_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
+/// You can use this typedef as a base class for your DrivableWidget
+///
+/// ```dart
+/// class MyCustomWidget extends $CoffeeCounterDrivableWidget {
+///     ...
+/// }
+/// ```
+typedef $CoffeeCounterDrivableWidget = DrivableWidget<CoffeeCounterWidgetDriver,
+    $CoffeeCounterWidgetDriverProvider>;
+
 class _$TestCoffeeCounterWidgetDriver extends TestDriver
     implements CoffeeCounterWidgetDriver {
   @override
@@ -30,8 +40,8 @@ class _$TestCoffeeCounterWidgetDriver extends TestDriver
 class $CoffeeCounterWidgetDriverProvider
     extends WidgetDriverProvider<CoffeeCounterWidgetDriver> {
   @override
-  CoffeeCounterWidgetDriver buildDriver() {
-    return CoffeeCounterWidgetDriver();
+  CoffeeCounterWidgetDriver buildDriver(BuildContext context) {
+    return CoffeeCounterWidgetDriver(context);
   }
 
   @override
@@ -39,6 +49,3 @@ class $CoffeeCounterWidgetDriverProvider
     return _$TestCoffeeCounterWidgetDriver();
   }
 }
-
-typedef $CoffeeCounterDrivableWidget = DrivableWidget<CoffeeCounterWidgetDriver,
-    $CoffeeCounterWidgetDriverProvider>;

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.dart
@@ -11,16 +11,14 @@ part 'random_coffee_image_widget_driver.g.dart';
 @Driver()
 class RandomCoffeeImageWidgetDriver extends WidgetDriver {
   final CoffeeImageService _coffeeImageService;
-  late final Localization _localization;
+  final Localization _localization;
 
-  RandomCoffeeImageWidgetDriver({
+  RandomCoffeeImageWidgetDriver(
+    BuildContext context, {
     CoffeeImageService? coffeeImageService,
-  }) : _coffeeImageService = coffeeImageService ?? GetIt.I.get<CoffeeImageService>();
-
-  @override
-  void setUpFromBuildContext(BuildContext context) {
-    _localization = context.read<Localization>();
-  }
+  })  : _coffeeImageService = coffeeImageService ?? GetIt.I.get<CoffeeImageService>(),
+        _localization = context.read<Localization>(),
+        super(context);
 
   @DriverProperty(TestCoffee.testCoffeeImageUrl)
   String get coffeeImageUrl {

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
@@ -6,6 +6,16 @@ part of 'random_coffee_image_widget_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
+/// You can use this typedef as a base class for your DrivableWidget
+///
+/// ```dart
+/// class MyCustomWidget extends $RandomCoffeeImageDrivableWidget {
+///     ...
+/// }
+/// ```
+typedef $RandomCoffeeImageDrivableWidget = DrivableWidget<
+    RandomCoffeeImageWidgetDriver, $RandomCoffeeImageWidgetDriverProvider>;
+
 class _$TestRandomCoffeeImageWidgetDriver extends TestDriver
     implements RandomCoffeeImageWidgetDriver {
   @override
@@ -21,8 +31,8 @@ class _$TestRandomCoffeeImageWidgetDriver extends TestDriver
 class $RandomCoffeeImageWidgetDriverProvider
     extends WidgetDriverProvider<RandomCoffeeImageWidgetDriver> {
   @override
-  RandomCoffeeImageWidgetDriver buildDriver() {
-    return RandomCoffeeImageWidgetDriver();
+  RandomCoffeeImageWidgetDriver buildDriver(BuildContext context) {
+    return RandomCoffeeImageWidgetDriver(context);
   }
 
   @override
@@ -30,6 +40,3 @@ class $RandomCoffeeImageWidgetDriverProvider
     return _$TestRandomCoffeeImageWidgetDriver();
   }
 }
-
-typedef $RandomCoffeeImageDrivableWidget = DrivableWidget<
-    RandomCoffeeImageWidgetDriver, $RandomCoffeeImageWidgetDriverProvider>;

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
@@ -11,14 +11,12 @@ class HomePageDriver extends WidgetDriver {
   final HomePageAppTabs _appTabs;
   late final Localization _localization;
 
-  HomePageDriver({
+  HomePageDriver(
+    BuildContext context, {
     HomePageAppTabs? appTabs,
-  }) : _appTabs = appTabs ?? HomePageAppTabs();
-
-  @override
-  void setUpFromBuildContext(BuildContext context) {
-    _localization = context.read<Localization>();
-  }
+  })  : _appTabs = appTabs ?? HomePageAppTabs(),
+        _localization = context.read<Localization>(),
+        super(context);
 
   @DriverProperty('Coffee Demo App')
   String get title => _localization.appTitle;

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
@@ -6,6 +6,16 @@ part of 'home_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
+/// You can use this typedef as a base class for your DrivableWidget
+///
+/// ```dart
+/// class MyCustomWidget extends $HomePageDrivableWidget {
+///     ...
+/// }
+/// ```
+typedef $HomePageDrivableWidget
+    = DrivableWidget<HomePageDriver, $HomePageDriverProvider>;
+
 class _$TestHomePageDriver extends TestDriver implements HomePageDriver {
   @override
   String get title => 'Coffee Demo App';
@@ -20,8 +30,8 @@ class _$TestHomePageDriver extends TestDriver implements HomePageDriver {
 
 class $HomePageDriverProvider extends WidgetDriverProvider<HomePageDriver> {
   @override
-  HomePageDriver buildDriver() {
-    return HomePageDriver();
+  HomePageDriver buildDriver(BuildContext context) {
+    return HomePageDriver(context);
   }
 
   @override
@@ -29,6 +39,3 @@ class $HomePageDriverProvider extends WidgetDriverProvider<HomePageDriver> {
     return _$TestHomePageDriver();
   }
 }
-
-typedef $HomePageDrivableWidget
-    = DrivableWidget<HomePageDriver, $HomePageDriverProvider>;

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.dart
@@ -10,18 +10,17 @@ part 'log_in_out_button_driver.g.dart';
 
 @Driver()
 class LogInOutButtonDriver extends WidgetDriver {
-  late AuthService _authService;
+  final AuthService _authService;
+  final Localization _localization;
   StreamSubscription? _subscription;
-  late final Localization _localization;
 
-  @override
-  void setUpFromBuildContext(BuildContext context) {
-    _authService = context.read<AuthService>();
+  LogInOutButtonDriver(BuildContext context)
+      : _authService = context.read<AuthService>(),
+        _localization = context.read<Localization>(),
+        super(context) {
     _subscription = _authService.isLoggedInStream.listen((_) {
       notifyWidget();
     });
-
-    _localization = context.read<Localization>();
   }
 
   @DriverProperty('Log in')

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
@@ -6,6 +6,16 @@ part of 'log_in_out_button_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
+/// You can use this typedef as a base class for your DrivableWidget
+///
+/// ```dart
+/// class MyCustomWidget extends $LogInOutButtonDrivableWidget {
+///     ...
+/// }
+/// ```
+typedef $LogInOutButtonDrivableWidget
+    = DrivableWidget<LogInOutButtonDriver, $LogInOutButtonDriverProvider>;
+
 class _$TestLogInOutButtonDriver extends TestDriver
     implements LogInOutButtonDriver {
   @override
@@ -18,8 +28,8 @@ class _$TestLogInOutButtonDriver extends TestDriver
 class $LogInOutButtonDriverProvider
     extends WidgetDriverProvider<LogInOutButtonDriver> {
   @override
-  LogInOutButtonDriver buildDriver() {
-    return LogInOutButtonDriver();
+  LogInOutButtonDriver buildDriver(BuildContext context) {
+    return LogInOutButtonDriver(context);
   }
 
   @override
@@ -27,6 +37,3 @@ class $LogInOutButtonDriverProvider
     return _$TestLogInOutButtonDriver();
   }
 }
-
-typedef $LogInOutButtonDrivableWidget
-    = DrivableWidget<LogInOutButtonDriver, $LogInOutButtonDriverProvider>;

--- a/widget_driver/example/lib/widgets/my_app_driver.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.dart
@@ -7,12 +7,11 @@ part 'my_app_driver.g.dart';
 
 @Driver()
 class MyAppDriver extends WidgetDriver {
-  late final Localization _localization;
+  final Localization _localization;
 
-  @override
-  void setUpFromBuildContext(BuildContext context) {
-    _localization = context.read<Localization>();
-  }
+  MyAppDriver(BuildContext context)
+      : _localization = context.read<Localization>(),
+        super(context);
 
   @DriverProperty('Coffee Demo App')
   String get appTitle => _localization.appTitle;

--- a/widget_driver/example/lib/widgets/my_app_driver.g.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.g.dart
@@ -6,6 +6,16 @@ part of 'my_app_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
+/// You can use this typedef as a base class for your DrivableWidget
+///
+/// ```dart
+/// class MyCustomWidget extends $MyAppDrivableWidget {
+///     ...
+/// }
+/// ```
+typedef $MyAppDrivableWidget
+    = DrivableWidget<MyAppDriver, $MyAppDriverProvider>;
+
 class _$TestMyAppDriver extends TestDriver implements MyAppDriver {
   @override
   String get appTitle => 'Coffee Demo App';
@@ -13,8 +23,8 @@ class _$TestMyAppDriver extends TestDriver implements MyAppDriver {
 
 class $MyAppDriverProvider extends WidgetDriverProvider<MyAppDriver> {
   @override
-  MyAppDriver buildDriver() {
-    return MyAppDriver();
+  MyAppDriver buildDriver(BuildContext context) {
+    return MyAppDriver(context);
   }
 
   @override
@@ -22,6 +32,3 @@ class $MyAppDriverProvider extends WidgetDriverProvider<MyAppDriver> {
     return _$TestMyAppDriver();
   }
 }
-
-typedef $MyAppDrivableWidget
-    = DrivableWidget<MyAppDriver, $MyAppDriverProvider>;

--- a/widget_driver/example/test/widget_tests/home_page/home_page_test.dart
+++ b/widget_driver/example/test/widget_tests/home_page/home_page_test.dart
@@ -56,7 +56,7 @@ void main() {
       // Try changing the title and verify it updates correctly
       when(() => mockHomePageDriver.title).thenReturn(mockOtherTitle);
       mockHomePageDriver.notifyWidget();
-      await tester.pumpAndSettle();
+      await tester.pumpWidget(homePage);
 
       expect(find.text(mockTitle), findsNothing);
       expect(find.text(mockOtherTitle), findsOneWidget);

--- a/widget_driver/lib/src/widget_driver.dart
+++ b/widget_driver/lib/src/widget_driver.dart
@@ -7,7 +7,7 @@ abstract class WidgetDriver<FC extends FlowCoordinator> {
   FC? flowCoordinator;
   final ValueNotifier<bool> _widgetNotifier = ValueNotifier<bool>(true);
 
-  void setUpFromBuildContext(BuildContext context) {}
+  WidgetDriver(BuildContext context);
 
   @nonVirtual
   void notifyWidget() {
@@ -30,8 +30,6 @@ class TestDriver {
   dynamic noSuchMethod(Invocation invocation) {
     return super.noSuchMethod(invocation);
   }
-
-  void setUpFromBuildContext(BuildContext context) {}
 
   void addListener(VoidCallback listener) {}
 

--- a/widget_driver/lib/src/widget_driver_provider.dart
+++ b/widget_driver/lib/src/widget_driver_provider.dart
@@ -1,7 +1,9 @@
+import 'package:flutter/material.dart';
+
 import 'flow_coordinator.dart';
 import 'widget_driver.dart';
 
 abstract class WidgetDriverProvider<Driver extends WidgetDriver<FlowCoordinator>> {
-  Driver buildDriver();
+  Driver buildDriver(BuildContext context);
   Driver buildTestDriver();
 }

--- a/widget_driver_generator/lib/src/widget_driver_generator.dart
+++ b/widget_driver_generator/lib/src/widget_driver_generator.dart
@@ -13,6 +13,29 @@ class WidgetDriverGenerator extends GeneratorForAnnotation<Driver> {
 
     final classBuffer = StringBuffer();
     final driverClassName = visitor.className;
+    final providerClassName = '\$${driverClassName}Provider';
+
+    //###################################
+    // Start - typedef generation
+    //###################################
+
+    final postfix = "DrivableWidget";
+    String typedefName = driverClassName.replaceAll("WidgetDriver", postfix);
+    if (typedefName == driverClassName) {
+      typedefName = driverClassName.replaceAll("Driver", postfix);
+    }
+    if (typedefName == driverClassName) {
+      typedefName = "${typedefName}${postfix}";
+    }
+
+    classBuffer.writeln('/// You can use this typedef as a base class for your DrivableWidget');
+    classBuffer.writeln('///');
+    classBuffer.writeln('/// ```dart');
+    classBuffer.writeln('/// class MyCustomWidget extends \$${typedefName} {');
+    classBuffer.writeln('///     ...');
+    classBuffer.writeln('/// }');
+    classBuffer.writeln('/// ```');
+    classBuffer.writeln('typedef \$${typedefName} = DrivableWidget<${driverClassName}, ${providerClassName}>;');
 
     //###################################
     // Start - TestDriver generation
@@ -29,13 +52,11 @@ class WidgetDriverGenerator extends GeneratorForAnnotation<Driver> {
     // Start - DriverProvider generation
     //###################################
 
-    final providerClassName = '\$${driverClassName}Provider';
-
     classBuffer.writeln('class $providerClassName extends WidgetDriverProvider<$driverClassName> {');
 
     classBuffer.writeln('@override');
-    classBuffer.writeln('$driverClassName buildDriver() {');
-    classBuffer.writeln('return $driverClassName();');
+    classBuffer.writeln('$driverClassName buildDriver(BuildContext context) {');
+    classBuffer.writeln('return $driverClassName(context);');
     classBuffer.writeln('}');
 
     classBuffer.writeln('@override');
@@ -44,21 +65,6 @@ class WidgetDriverGenerator extends GeneratorForAnnotation<Driver> {
     classBuffer.writeln('}');
 
     classBuffer.writeln('}');
-
-    //###################################
-    // Start - typedef generation
-    //###################################
-
-    final postfix = "DrivableWidget";
-    String typedefName = driverClassName.replaceAll("WidgetDriver", postfix);
-    if (typedefName == driverClassName) {
-      typedefName = driverClassName.replaceAll("Driver", postfix);
-    }
-    if (typedefName == driverClassName) {
-      typedefName = "${typedefName}${postfix}";
-    }
-
-    classBuffer.writeln('typedef \$${typedefName} = DrivableWidget<${driverClassName}, ${providerClassName}>;');
 
     return classBuffer.toString();
   }


### PR DESCRIPTION
This PR changes 3 things:

- BuildContext is now passed directly to constructor of Driver. No longer passed via optional "setUp" method
- License got updated to be licensed to BMW Group AG instead of BMW tech coorp
- Updated generator to create some useful documentation for DrivableWidget-typedef