### PR TITLE
Changes the example app to use concrete DrivableWidget type

### DIFF
--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page.dart
@@ -1,10 +1,11 @@
 import 'package:example/widgets/coffee_community/coffee_library/coffee_library_page.dart';
 import 'package:example/widgets/coffee_community/not_logged_in/not_logged_in_page.dart';
 import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
 
 import 'coffee_community_page_driver.dart';
 
-class CoffeeCommunityPage extends $CoffeeCommunityPageDrivableWidget {
+class CoffeeCommunityPage extends DrivableWidget<CoffeeCommunityPageDriver> {
   CoffeeCommunityPage({Key? key}) : super(key: key);
 
   @override
@@ -17,5 +18,6 @@ class CoffeeCommunityPage extends $CoffeeCommunityPageDrivableWidget {
   }
 
   @override
-  $CoffeeCommunityPageDriverProvider get driverProvider => $CoffeeCommunityPageDriverProvider();
+  WidgetDriverProvider<CoffeeCommunityPageDriver> get driverProvider =>
+      $CoffeeCommunityPageDriverProvider();
 }

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
@@ -6,16 +6,6 @@ part of 'coffee_community_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
-/// You can use this typedef as a base class for your DrivableWidget
-///
-/// ```dart
-/// class MyCustomWidget extends $CoffeeCommunityPageDrivableWidget {
-///     ...
-/// }
-/// ```
-typedef $CoffeeCommunityPageDrivableWidget = DrivableWidget<
-    CoffeeCommunityPageDriver, $CoffeeCommunityPageDriverProvider>;
-
 class _$TestCoffeeCommunityPageDriver extends TestDriver
     implements CoffeeCommunityPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page.dart
@@ -1,9 +1,10 @@
 import 'package:example/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.dart';
 import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
 
 import '../../../custom_widgets/cached_network_image.dart';
 
-class CoffeeDetailPage extends $CoffeeDetailPageDrivableWidget {
+class CoffeeDetailPage extends DrivableWidget<CoffeeDetailPageDriver> {
   CoffeeDetailPage({Key? key}) : super(key: key);
 
   @override
@@ -25,5 +26,6 @@ class CoffeeDetailPage extends $CoffeeDetailPageDrivableWidget {
   }
 
   @override
-  $CoffeeDetailPageDriverProvider get driverProvider => $CoffeeDetailPageDriverProvider();
+  WidgetDriverProvider<CoffeeDetailPageDriver> get driverProvider =>
+      $CoffeeDetailPageDriverProvider();
 }

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
@@ -6,16 +6,6 @@ part of 'coffee_detail_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
-/// You can use this typedef as a base class for your DrivableWidget
-///
-/// ```dart
-/// class MyCustomWidget extends $CoffeeDetailPageDrivableWidget {
-///     ...
-/// }
-/// ```
-typedef $CoffeeDetailPageDrivableWidget
-    = DrivableWidget<CoffeeDetailPageDriver, $CoffeeDetailPageDriverProvider>;
-
 class _$TestCoffeeDetailPageDriver extends TestDriver
     implements CoffeeDetailPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page.dart
@@ -1,9 +1,10 @@
 import 'package:example/widgets/coffee_community/coffee_library/coffee_row.dart';
 import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
 
 import 'coffee_library_page_driver.dart';
 
-class CoffeeLibraryPage extends $CoffeeLibraryPageDrivableWidget {
+class CoffeeLibraryPage extends DrivableWidget<CoffeeLibraryPageDriver> {
   CoffeeLibraryPage({Key? key}) : super(key: key);
 
   @override
@@ -31,5 +32,6 @@ class CoffeeLibraryPage extends $CoffeeLibraryPageDrivableWidget {
   }
 
   @override
-  $CoffeeLibraryPageDriverProvider get driverProvider => $CoffeeLibraryPageDriverProvider();
+  WidgetDriverProvider<CoffeeLibraryPageDriver> get driverProvider =>
+      $CoffeeLibraryPageDriverProvider();
 }

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
@@ -6,16 +6,6 @@ part of 'coffee_library_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
-/// You can use this typedef as a base class for your DrivableWidget
-///
-/// ```dart
-/// class MyCustomWidget extends $CoffeeLibraryPageDrivableWidget {
-///     ...
-/// }
-/// ```
-typedef $CoffeeLibraryPageDrivableWidget
-    = DrivableWidget<CoffeeLibraryPageDriver, $CoffeeLibraryPageDriverProvider>;
-
 class _$TestCoffeeLibraryPageDriver extends TestDriver
     implements CoffeeLibraryPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
 
 import 'not_logged_in_page_driver.dart';
 
-class NotLoggedInPage extends $NotLoggedInPageDrivableWidget {
+class NotLoggedInPage extends DrivableWidget<NotLoggedInPageDriver> {
   NotLoggedInPage({Key? key}) : super(key: key);
 
   @override
@@ -11,5 +12,6 @@ class NotLoggedInPage extends $NotLoggedInPageDrivableWidget {
   }
 
   @override
-  $NotLoggedInPageDriverProvider get driverProvider => $NotLoggedInPageDriverProvider();
+  WidgetDriverProvider<NotLoggedInPageDriver> get driverProvider =>
+      $NotLoggedInPageDriverProvider();
 }

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
@@ -6,16 +6,6 @@ part of 'not_logged_in_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
-/// You can use this typedef as a base class for your DrivableWidget
-///
-/// ```dart
-/// class MyCustomWidget extends $NotLoggedInPageDrivableWidget {
-///     ...
-/// }
-/// ```
-typedef $NotLoggedInPageDrivableWidget
-    = DrivableWidget<NotLoggedInPageDriver, $NotLoggedInPageDriverProvider>;
-
 class _$TestNotLoggedInPageDriver extends TestDriver
     implements NotLoggedInPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
 
 import 'coffee_counter_widget_driver.dart';
 
-class CoffeeCounterWidget extends $CoffeeCounterDrivableWidget {
+class CoffeeCounterWidget extends DrivableWidget<CoffeeCounterWidgetDriver> {
   CoffeeCounterWidget({Key? key}) : super(key: key);
 
   @override
@@ -27,5 +28,6 @@ class CoffeeCounterWidget extends $CoffeeCounterDrivableWidget {
   }
 
   @override
-  $CoffeeCounterWidgetDriverProvider get driverProvider => $CoffeeCounterWidgetDriverProvider();
+  WidgetDriverProvider<CoffeeCounterWidgetDriver> get driverProvider =>
+      $CoffeeCounterWidgetDriverProvider();
 }

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
@@ -6,16 +6,6 @@ part of 'coffee_counter_widget_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
-/// You can use this typedef as a base class for your DrivableWidget
-///
-/// ```dart
-/// class MyCustomWidget extends $CoffeeCounterDrivableWidget {
-///     ...
-/// }
-/// ```
-typedef $CoffeeCounterDrivableWidget = DrivableWidget<CoffeeCounterWidgetDriver,
-    $CoffeeCounterWidgetDriverProvider>;
-
 class _$TestCoffeeCounterWidgetDriver extends TestDriver
     implements CoffeeCounterWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
 
 import '../../custom_widgets/cached_network_image.dart';
 import 'random_coffee_image_widget_driver.dart';
 
-class RandomCoffeeImageWidget extends $RandomCoffeeImageDrivableWidget {
+class RandomCoffeeImageWidget
+    extends DrivableWidget<RandomCoffeeImageWidgetDriver> {
   RandomCoffeeImageWidget({Key? key}) : super(key: key);
 
   @override
@@ -21,5 +23,6 @@ class RandomCoffeeImageWidget extends $RandomCoffeeImageDrivableWidget {
   }
 
   @override
-  $RandomCoffeeImageWidgetDriverProvider get driverProvider => $RandomCoffeeImageWidgetDriverProvider();
+  WidgetDriverProvider<RandomCoffeeImageWidgetDriver> get driverProvider =>
+      $RandomCoffeeImageWidgetDriverProvider();
 }

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
@@ -6,16 +6,6 @@ part of 'random_coffee_image_widget_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
-/// You can use this typedef as a base class for your DrivableWidget
-///
-/// ```dart
-/// class MyCustomWidget extends $RandomCoffeeImageDrivableWidget {
-///     ...
-/// }
-/// ```
-typedef $RandomCoffeeImageDrivableWidget = DrivableWidget<
-    RandomCoffeeImageWidgetDriver, $RandomCoffeeImageWidgetDriverProvider>;
-
 class _$TestRandomCoffeeImageWidgetDriver extends TestDriver
     implements RandomCoffeeImageWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/home_page/home_page.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
 
 import 'home_page_driver.dart';
 import 'log_in_out_button/log_in_out_button.dart';
 import 'tabs/home_page_tabs.dart';
 import 'tabs/home_page_tabs_builder.dart';
 
-class HomePage extends $HomePageDrivableWidget {
+class HomePage extends DrivableWidget<HomePageDriver> {
   HomePage({Key? key}) : super(key: key);
 
   @override
@@ -16,7 +17,8 @@ class HomePage extends $HomePageDrivableWidget {
         appBar: AppBar(
           bottom: TabBar(
             tabs: [
-              for (var appTab in driver.appTabs) Tab(icon: Icon(appTab.iconData)),
+              for (var appTab in driver.appTabs)
+                Tab(icon: Icon(appTab.iconData)),
             ],
           ),
           title: Text(driver.title),
@@ -24,7 +26,8 @@ class HomePage extends $HomePageDrivableWidget {
         ),
         body: TabBarView(
           children: [
-            for (var appTab in driver.appTabs) HomePageTabBuilder.tabForType(appTab),
+            for (var appTab in driver.appTabs)
+              HomePageTabBuilder.tabForType(appTab),
           ],
         ),
       ),
@@ -32,5 +35,6 @@ class HomePage extends $HomePageDrivableWidget {
   }
 
   @override
-  $HomePageDriverProvider get driverProvider => $HomePageDriverProvider();
+  WidgetDriverProvider<HomePageDriver> get driverProvider =>
+      $HomePageDriverProvider();
 }

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
@@ -6,16 +6,6 @@ part of 'home_page_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
-/// You can use this typedef as a base class for your DrivableWidget
-///
-/// ```dart
-/// class MyCustomWidget extends $HomePageDrivableWidget {
-///     ...
-/// }
-/// ```
-typedef $HomePageDrivableWidget
-    = DrivableWidget<HomePageDriver, $HomePageDriverProvider>;
-
 class _$TestHomePageDriver extends TestDriver implements HomePageDriver {
   @override
   String get title => 'Coffee Demo App';

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
 
 import 'log_in_out_button_driver.dart';
 
-class LogInOutButton extends $LogInOutButtonDrivableWidget {
+class LogInOutButton extends DrivableWidget<LogInOutButtonDriver> {
   LogInOutButton({Key? key}) : super(key: key);
 
   @override
@@ -26,5 +27,6 @@ class LogInOutButton extends $LogInOutButtonDrivableWidget {
   }
 
   @override
-  $LogInOutButtonDriverProvider get driverProvider => $LogInOutButtonDriverProvider();
+  WidgetDriverProvider<LogInOutButtonDriver> get driverProvider =>
+      $LogInOutButtonDriverProvider();
 }

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
@@ -6,16 +6,6 @@ part of 'log_in_out_button_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
-/// You can use this typedef as a base class for your DrivableWidget
-///
-/// ```dart
-/// class MyCustomWidget extends $LogInOutButtonDrivableWidget {
-///     ...
-/// }
-/// ```
-typedef $LogInOutButtonDrivableWidget
-    = DrivableWidget<LogInOutButtonDriver, $LogInOutButtonDriverProvider>;
-
 class _$TestLogInOutButtonDriver extends TestDriver
     implements LogInOutButtonDriver {
   @override

--- a/widget_driver/example/lib/widgets/my_app.dart
+++ b/widget_driver/example/lib/widgets/my_app.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
 
 import 'home_page/home_page.dart';
 import 'my_app_driver.dart';
 
-class MyApp extends $MyAppDrivableWidget {
+class MyApp extends DrivableWidget<MyAppDriver> {
   MyApp({Key? key}) : super(key: key);
 
   @override
@@ -18,5 +19,6 @@ class MyApp extends $MyAppDrivableWidget {
   }
 
   @override
-  $MyAppDriverProvider get driverProvider => $MyAppDriverProvider();
+  WidgetDriverProvider<MyAppDriver> get driverProvider =>
+      $MyAppDriverProvider();
 }

--- a/widget_driver/example/lib/widgets/my_app_driver.g.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.g.dart
@@ -6,16 +6,6 @@ part of 'my_app_driver.dart';
 // WidgetDriverGenerator
 // **************************************************************************
 
-/// You can use this typedef as a base class for your DrivableWidget
-///
-/// ```dart
-/// class MyCustomWidget extends $MyAppDrivableWidget {
-///     ...
-/// }
-/// ```
-typedef $MyAppDrivableWidget
-    = DrivableWidget<MyAppDriver, $MyAppDriverProvider>;
-
 class _$TestMyAppDriver extends TestDriver implements MyAppDriver {
   @override
   String get appTitle => 'Coffee Demo App';

--- a/widget_driver/lib/src/drivable_widget.dart
+++ b/widget_driver/lib/src/drivable_widget.dart
@@ -11,7 +11,7 @@ export 'package:flutter/widgets.dart' show BuildContext;
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 
 /// A base class for widgets which can be driven by a WidgetDriver.
-abstract class DrivableWidget<Driver extends WidgetDriver, DriverProvider extends WidgetDriverProvider<Driver>>
+abstract class DrivableWidget<Driver extends WidgetDriver>
     extends StatefulWidget {
   DrivableWidget({
     Key? key,
@@ -20,7 +20,7 @@ abstract class DrivableWidget<Driver extends WidgetDriver, DriverProvider extend
         super(key: key);
 
   /// The provider which knows how to create the Driver for this widget.
-  DriverProvider get driverProvider;
+  WidgetDriverProvider<Driver> get driverProvider;
 
   /// The driver which drives this widget.
   ///
@@ -36,11 +36,11 @@ abstract class DrivableWidget<Driver extends WidgetDriver, DriverProvider extend
 
   @nonVirtual
   @override
-  State<DrivableWidget<Driver, DriverProvider>> createState() => _DriverWidgetState<Driver, DriverProvider>();
+  State<DrivableWidget<Driver>> createState() => _DriverWidgetState<Driver>();
 }
 
-class _DriverWidgetState<Driver extends WidgetDriver, DriverProvider extends WidgetDriverProvider<Driver>>
-    extends State<DrivableWidget<Driver, DriverProvider>> {
+class _DriverWidgetState<Driver extends WidgetDriver>
+    extends State<DrivableWidget<Driver>> {
   Driver? _driver;
 
   @override

--- a/widget_driver_generator/lib/src/widget_driver_generator.dart
+++ b/widget_driver_generator/lib/src/widget_driver_generator.dart
@@ -7,7 +7,8 @@ import 'model_visitor.dart';
 
 class WidgetDriverGenerator extends GeneratorForAnnotation<Driver> {
   @override
-  Future<String> generateForAnnotatedElement(Element element, ConstantReader annotation, BuildStep buildStep) async {
+  Future<String> generateForAnnotatedElement(
+      Element element, ConstantReader annotation, BuildStep buildStep) async {
     final visitor = ModelVisitor();
     element.visitChildren(visitor);
 
@@ -16,34 +17,13 @@ class WidgetDriverGenerator extends GeneratorForAnnotation<Driver> {
     final providerClassName = '\$${driverClassName}Provider';
 
     //###################################
-    // Start - typedef generation
-    //###################################
-
-    final postfix = "DrivableWidget";
-    String typedefName = driverClassName.replaceAll("WidgetDriver", postfix);
-    if (typedefName == driverClassName) {
-      typedefName = driverClassName.replaceAll("Driver", postfix);
-    }
-    if (typedefName == driverClassName) {
-      typedefName = "${typedefName}${postfix}";
-    }
-
-    classBuffer.writeln('/// You can use this typedef as a base class for your DrivableWidget');
-    classBuffer.writeln('///');
-    classBuffer.writeln('/// ```dart');
-    classBuffer.writeln('/// class MyCustomWidget extends \$${typedefName} {');
-    classBuffer.writeln('///     ...');
-    classBuffer.writeln('/// }');
-    classBuffer.writeln('/// ```');
-    classBuffer.writeln('typedef \$${typedefName} = DrivableWidget<${driverClassName}, ${providerClassName}>;');
-
-    //###################################
     // Start - TestDriver generation
     //###################################
 
     final testDriverClassName = '_\$Test${driverClassName}';
 
-    classBuffer.writeln('class $testDriverClassName extends TestDriver implements $driverClassName {');
+    classBuffer.writeln(
+        'class $testDriverClassName extends TestDriver implements $driverClassName {');
     final annotationVisitor = AnnotationVisitor(classBuffer);
     element.visitChildren(annotationVisitor);
     classBuffer.writeln('}');
@@ -52,7 +32,8 @@ class WidgetDriverGenerator extends GeneratorForAnnotation<Driver> {
     // Start - DriverProvider generation
     //###################################
 
-    classBuffer.writeln('class $providerClassName extends WidgetDriverProvider<$driverClassName> {');
+    classBuffer.writeln(
+        'class $providerClassName extends WidgetDriverProvider<$driverClassName> {');
 
     classBuffer.writeln('@override');
     classBuffer.writeln('$driverClassName buildDriver(BuildContext context) {');

--- a/widget_driver_test/pubspec.lock
+++ b/widget_driver_test/pubspec.lock
@@ -5,91 +5,91 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "40.0.0"
+    version: "47.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.7.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.1"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.16.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.4"
   flutter:
@@ -106,149 +106,149 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.5"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.5"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   mocktail:
     dependency: "direct main"
     description:
       name: mocktail
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -258,112 +258,112 @@ packages:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.11"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct main"
     description:
       name: test
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.21.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "9.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   widget_driver:
@@ -384,9 +384,9 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      url: "https://mobile20unpubfrontdoor.azurefd.net"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=2.6.0"


### PR DESCRIPTION
Changes how you define widgets that can use Drivers.
Before, we auto-generated a specific typedef for each DrivableWidget.

I added this since otherwise it would always be such a long definition in the widget.
This is what you had to write before:

```dart
class MyWidget extends DrivableWidget<MyWidgetDriver, MyWidgetDriverProvider> {
..
}
```
So I created a typedef for the `DrivableWidget<MyWidgetDriver, MyWidgetDriverProvider>` which is then called: `$MyWidgetDrivableWidget`
And then you used this like this:
```dart
class MyWidget extends $MyWidgetDrivableWidget {
..
}
```
But this still feels a bit strange.. You always have a new base type for your widgets.. 
It would be nicer if you always can have "DrivableWidget" as your base class.


But then I realised that I can clean up the interface in the DrivableWidget. It does not need the gerneric type for the provider.. So I can turn in the needed definition to be this instead: 
```dart
class MyWidget extends DrivableWidget<MyWidgetDriver> {
..
}
```

And I think this is nicer.


So lets go this way instead..

BENEFITS:

- It is clear for all widgets which have drivers that they are all "DrivableWidgets"
- We do not need to spam the dart runtime with typedef-types.. Before there would be one extra type for each Driver..