### PR TITLE
Adds link to repositories to the pubspec files

### DIFF
--- a/widget_driver/pubspec.yaml
+++ b/widget_driver/pubspec.yaml
@@ -1,7 +1,7 @@
 name: widget_driver
 description: A Flutter presentation layer framework, which will clean up your widget code and make your widgets testable without a need for thousands of mock objects. Let's go driving!
-homepage: https://github.com/bmw-tech/widget_driver
 version: 0.0.1
+repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
 environment:

--- a/widget_driver_annotation/pubspec.yaml
+++ b/widget_driver_annotation/pubspec.yaml
@@ -1,6 +1,8 @@
 name: widget_driver_annotation
 description: Annotations for WidgetDriver
 version: 0.0.1
+repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_annotation
+issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/widget_driver_generator/pubspec.yaml
+++ b/widget_driver_generator/pubspec.yaml
@@ -1,6 +1,8 @@
 name: widget_driver_generator
 description: Generator for WidgetDriver
 version: 0.0.1
+repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_generator
+issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -1,6 +1,8 @@
 name: widget_driver_test
 description: Test helpers for WidgetDriver
 version: 0.0.1
+repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_test
+issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
According to this guide on publishing dart packages, it is good to add a link to the repos in the pubspec yaml: https://docs.flutter.dev/development/packages-and-plugins/developing-packages#publish

Fixes this issue: #41