### PR TITLE
remove subosito/flutter-action@v2 step from test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '2.10.5'
-        channel: 'stable'
     - name: Flutter version
       run: flutter --version
     - name: Test widget_driver_annotation


### PR DESCRIPTION
the subosito/flutter-action step is taking the most time of the test action and is evidently unnecessary. Therefore we should remove it.