### PR TITLE
[39] Use pipeline checks script for each PR

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -1,0 +1,21 @@
+name: check-code-quality
+on:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  check-code-quality:
+    if: ${{ github.event.label.name == 'ready for pipeline' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.3.4'
+          channel: 'stable'
+
+      - name: Run quality checks
+        run: |
+          git config --global --add safe.directory /opt/hostedtoolcache/flutter/stable-3.3.4-x64
+          make quality

--- a/.github/workflows/how-to-run-workflows-locally.md
+++ b/.github/workflows/how-to-run-workflows-locally.md
@@ -1,0 +1,14 @@
+# Run GitHub Actions on Your Machine
+We use github actions to check if the code is sound and in the format we expect before it can be merged to master.
+It is possible to run the actions locally with [act](https://github.com/nektos/act).
+To run the `check-code-quality` action use the following command:
+```
+act -j check-code-quality
+```
+On your first run you will be asked which image size you want to use. 
+Our pipeline actions have requirements that are not automatically meat by the micro image, so please use at least the medium image.
+The default used image can also be changed in your `~/.actrc` file. 
+Furthermore there is the option to specify the image used by setting it as a parameter:
+```
+act -j check-code-quality -P ubuntu-latest=catthehacker/ubuntu:act-latest 
+```


### PR DESCRIPTION
We want to run the pipeline in every PR to master once the "ready-for-pipeline" label is set. Since this depends on https://github.com/bmw-tech/widget_driver/pull/51, we have to wait until it can get merged