### PR TITLE
Feature/update readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # WidgetDriver
 
+[![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
+[![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
+
 A Flutter presentation layer framework, which will clean up your  
 widget code and make your widgets testable without the need for thousands of mock objects.  
 Let's go driving! 🚙💨

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `WidgetDriver` framework is built up on different dart packages. The core pa
 
 Here is an overview of all the packages:
 
-## widget_driver
+## widget_driver  [![pub package](https://img.shields.io/pub/v/widget_driver.svg)](https://pub.dev/packages/widget_driver)
 
 - [Source code](widget_driver)
 
@@ -19,7 +19,7 @@ The core package which provides the `WidgetDriver` framework.
 
 Import it into your pubspec `dependencies:` section.
 
-## widget_driver_generator
+## widget_driver_generator [![pub package](https://img.shields.io/pub/v/widget_driver_generator.svg)](https://pub.dev/packages/widget_driver_generator)
 
 - [Source code](widget_driver_generator)
 
@@ -27,7 +27,7 @@ The package providing generators to automate the creation of your `TestDrivers` 
 
 Import it into your pubspec `dev_dependencies:` section.
 
-## widget_driver_annotation
+## widget_driver_annotation [![pub package](https://img.shields.io/pub/v/widget_driver_annotation.svg)](https://pub.dev/packages/widget_driver_annotation)
 
 - [Source code](widget_driver_annotation)
 
@@ -36,7 +36,7 @@ The annotation package which has no dependencies.
 You do not need to import this since the `widget_driver` package already imports it for you.  
 But if you need/want to import it then import it into your pubspec `dependencies:` section.
 
-## widget_driver_test
+## widget_driver_test [![pub package](https://img.shields.io/pub/v/widget_driver_test.svg)](https://pub.dev/packages/widget_driver_test)
 
 - [Source code](widget_driver_test)
 

--- a/widget_driver/README.md
+++ b/widget_driver/README.md
@@ -352,4 +352,4 @@ For e.g. if you choose to use [Provider](https://pub.dev/packages/provider), the
 - [Testing](doc/testing.md)
 - [Code generation](doc/code_generation.md)
 - [Using WidgetDrivers without code generation](doc/drivers_without_generation.md)
-- Contribution guide
+- [Contribution guide](../CONTRIBUTING.md)

--- a/widget_driver/README.md
+++ b/widget_driver/README.md
@@ -1,5 +1,8 @@
 # WidgetDriver
 
+[![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
+[![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
+
 A Flutter presentation layer framework, which will clean up your  
 widget code and make your widgets testable without a need for thousands of mock objects.  
 Let's go driving! 🚙💨

--- a/widget_driver/README.md
+++ b/widget_driver/README.md
@@ -1,5 +1,6 @@
 # WidgetDriver
 
+[![pub package](https://img.shields.io/pub/v/widget_driver.svg)](https://pub.dev/packages/widget_driver)
 [![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
 

--- a/widget_driver/analysis_options.yaml
+++ b/widget_driver/analysis_options.yaml
@@ -1,6 +1,4 @@
 include: package:flutter_lints/flutter.yaml
-analyzer:
-  errors:
-    invalid_dependency: ignore
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/widget_driver/example/pubspec.lock
+++ b/widget_driver/example/pubspec.lock
@@ -705,30 +705,30 @@ packages:
   widget_driver:
     dependency: "direct main"
     description:
-      path: ".."
-      relative: true
-    source: path
+      name: widget_driver
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
   widget_driver_annotation:
     dependency: transitive
     description:
-      path: "../../widget_driver_annotation"
-      relative: true
-    source: path
+      name: widget_driver_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
   widget_driver_generator:
     dependency: "direct dev"
     description:
-      path: "../../widget_driver_generator"
-      relative: true
-    source: path
+      name: widget_driver_generator
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
   widget_driver_test:
     dependency: "direct dev"
     description:
-      path: "../../widget_driver_test"
-      relative: true
-    source: path
+      name: widget_driver_test
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
   win32:
     dependency: transitive

--- a/widget_driver/example/pubspec.yaml
+++ b/widget_driver/example/pubspec.yaml
@@ -11,8 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  widget_driver:
-    path: ../
+  widget_driver: ^0.0.1
   meta: ^1.7.0
   get_it: ^7.2.0
   provider: ^6.0.4
@@ -24,11 +23,9 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^1.0.4
   mocktail: ^0.3.0
-  widget_driver_test:
-    path: ../../widget_driver_test/
+  widget_driver_test: ^0.0.1
   build_runner:
-  widget_driver_generator:
-    path: ../../widget_driver_generator/
+  widget_driver_generator: ^0.0.1
 
 flutter:
   uses-material-design: true

--- a/widget_driver/pubspec.lock
+++ b/widget_driver/pubspec.lock
@@ -152,9 +152,9 @@ packages:
   widget_driver_annotation:
     dependency: "direct main"
     description:
-      path: "../widget_driver_annotation"
-      relative: true
-    source: path
+      name: widget_driver_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
 sdks:
   dart: ">=2.17.0-0 <3.0.0"

--- a/widget_driver/pubspec.yaml
+++ b/widget_driver/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  widget_driver_annotation: 0.0.1
+  widget_driver_annotation: ^0.0.1
 
 dev_dependencies:
   flutter_test:

--- a/widget_driver_annotation/README.md
+++ b/widget_driver_annotation/README.md
@@ -1,5 +1,6 @@
 # WidgetDriver annotation
 
+[![pub package](https://img.shields.io/pub/v/widget_driver_annotation.svg)](https://pub.dev/packages/widget_driver_annotation)
 [![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
 

--- a/widget_driver_annotation/README.md
+++ b/widget_driver_annotation/README.md
@@ -1,5 +1,8 @@
 # WidgetDriver annotation
 
+[![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
+[![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
+
 Defines the annotations used by `widget_driver` and `widget_driver_generator` to create code for your `WidgetDrivers`.
 
 See the documentation for [widget_driver](../widget_driver) to understand how there annotations work and how you can configure and use them.

--- a/widget_driver_generator/README.md
+++ b/widget_driver_generator/README.md
@@ -1,5 +1,8 @@
 # WidgetDriver generator
 
+[![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
+[![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
+
 This is a helper package that supports the `widget_driver` package and generates the bootstrapping code needed to get your `Drivers` fully set up.
 
 ---

--- a/widget_driver_generator/README.md
+++ b/widget_driver_generator/README.md
@@ -1,5 +1,6 @@
 # WidgetDriver generator
 
+[![pub package](https://img.shields.io/pub/v/widget_driver_generator.svg)](https://pub.dev/packages/widget_driver_generator)
 [![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
 

--- a/widget_driver_generator/analysis_options.yaml
+++ b/widget_driver_generator/analysis_options.yaml
@@ -1,6 +1,4 @@
 include: package:flutter_lints/flutter.yaml
-analyzer:
-  errors:
-    invalid_dependency: ignore
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/widget_driver_generator/pubspec.lock
+++ b/widget_driver_generator/pubspec.lock
@@ -9,7 +9,7 @@ packages:
     source: hosted
     version: "50.0.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
@@ -432,9 +432,9 @@ packages:
   widget_driver_annotation:
     dependency: "direct main"
     description:
-      path: "../widget_driver_annotation"
-      relative: true
-    source: path
+      name: widget_driver_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
   yaml:
     dependency: transitive

--- a/widget_driver_generator/pubspec.yaml
+++ b/widget_driver_generator/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   build:
   source_gen:
   analyzer:
-  widget_driver_annotation: 0.0.1
+  widget_driver_annotation: ^0.0.1
 
 dev_dependencies:
   build_runner:

--- a/widget_driver_test/README.md
+++ b/widget_driver_test/README.md
@@ -1,5 +1,6 @@
 # WidgetDriver test
 
+[![pub package](https://img.shields.io/pub/v/widget_driver_test.svg)](https://pub.dev/packages/widget_driver_test)
 [![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
 

--- a/widget_driver_test/README.md
+++ b/widget_driver_test/README.md
@@ -1,5 +1,8 @@
 # WidgetDriver test
 
+[![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
+[![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
+
 A package that makes testing `WidgetDrivers` and `DrivableWidgets` easy.  
 Built to work with mocktail for easy mocking.
 

--- a/widget_driver_test/analysis_options.yaml
+++ b/widget_driver_test/analysis_options.yaml
@@ -1,6 +1,4 @@
 include: package:flutter_lints/flutter.yaml
-analyzer:
-  errors:
-    invalid_dependency: ignore
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/widget_driver_test/pubspec.lock
+++ b/widget_driver_test/pubspec.lock
@@ -93,7 +93,7 @@ packages:
     source: hosted
     version: "6.1.4"
   flutter:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -383,16 +383,16 @@ packages:
   widget_driver:
     dependency: "direct main"
     description:
-      path: "../widget_driver"
-      relative: true
-    source: path
+      name: widget_driver
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
   widget_driver_annotation:
     dependency: transitive
     description:
-      path: "../widget_driver_annotation"
-      relative: true
-    source: path
+      name: widget_driver_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
   yaml:
     dependency: transitive

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widget_driver: 0.0.1
+  widget_driver: ^0.0.1
   mocktail: ^0.3.0
   meta: ^1.7.0
   test: ^1.16.0


### PR DESCRIPTION
## Description
- Updates the readme with badge info about current build status, and license and latest deployed version to pub.dev
- Changes the example app pubspec to use pub.dev dependencies, and not the `path` anymore.
- Updates the flutter analyser config to again warn when using `path` in pubspec yaml

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [x] ⚙️ Build configuration change
- [x] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
