### PR TITLE
Fixes driverTesterHelper so that widgets are loaded correctly and diposed correctly

### DIFF
--- a/widget_driver/test/widget_driver_test.dart
+++ b/widget_driver/test/widget_driver_test.dart
@@ -74,7 +74,7 @@ void main() {
       1: Deploy new version of `widget_driver`
       2: Deploy new version of `widget_driver_test`
       3: Add this code back.
-
+      
     group('Lifecycle:', () {
       testWidgets('Calls dispose when driver gets deallocated', (WidgetTester tester) async {
         bool disposeWasCalled = false;
@@ -93,6 +93,22 @@ void main() {
         await tester.pumpWidget(const SizedBox.shrink());
 
         expect(disposeWasCalled, true);
+      });
+
+      testWidgets('Does not call dispose when the driver never gets deallocated', (WidgetTester tester) async {
+        bool disposeWasCalled = false;
+
+        final driverTester = await tester.getDriverTester(
+          driverBuilder: (context) => ConcreteWidgetDriver(context),
+        );
+        final driver = driverTester.driver;
+        driver.disposedCallback = () {
+          disposeWasCalled = true;
+        };
+
+        await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+        expect(disposeWasCalled, false);
       });
     });
     */

--- a/widget_driver_test/CHANGELOG.md
+++ b/widget_driver_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Fixes issue where driverTesterHelper didn't load and dispose drivers correctly.
+
 ## 0.0.1
 
 * Initial release.

--- a/widget_driver_test/lib/src/utils/test_drivable_widget.dart
+++ b/widget_driver_test/lib/src/utils/test_drivable_widget.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import 'test_runtime_environment_info.dart';
+import 'test_widget_driver_provider.dart';
+
+class TestDrivableWidget<T extends WidgetDriver> extends DrivableWidget<T> {
+  final T Function(BuildContext context) _driverBuilder;
+
+  TestDrivableWidget({
+    Key? key,
+    required T Function(BuildContext context) driverBuilder,
+  })  : _driverBuilder = driverBuilder,
+        super(key: key, environmentInfo: TestRuntimeEnvironmentInfo());
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+
+  @override
+  WidgetDriverProvider<T> get driverProvider => TestWidgetDriverProvider<T>(driverBuilder: _driverBuilder);
+}

--- a/widget_driver_test/lib/src/utils/test_drivable_widget.dart
+++ b/widget_driver_test/lib/src/utils/test_drivable_widget.dart
@@ -4,6 +4,10 @@ import 'package:widget_driver/widget_driver.dart';
 import 'test_runtime_environment_info.dart';
 import 'test_widget_driver_provider.dart';
 
+/// This is a helper widget which is used by the `WidgetTester`
+/// extension to help with the creation of a driver.
+/// This widget will be used as a container for your driver.
+/// It makes sure that your driver is created and disposed correctly.
 class TestDrivableWidget<T extends WidgetDriver> extends DrivableWidget<T> {
   final T Function(BuildContext context) _driverBuilder;
 

--- a/widget_driver_test/lib/src/utils/test_runtime_environment_info.dart
+++ b/widget_driver_test/lib/src/utils/test_runtime_environment_info.dart
@@ -1,0 +1,8 @@
+import 'package:widget_driver/widget_driver.dart';
+
+class TestRuntimeEnvironmentInfo implements RuntimeEnvironmentInfo {
+  @override
+  bool isRunningInTestEnvironment() {
+    return false;
+  }
+}

--- a/widget_driver_test/lib/src/utils/test_runtime_environment_info.dart
+++ b/widget_driver_test/lib/src/utils/test_runtime_environment_info.dart
@@ -1,5 +1,17 @@
 import 'package:widget_driver/widget_driver.dart';
 
+/// This is a wrapper around [RuntimeEnvironmentInfo] to make sure that
+/// the `TestDrivableWidget` can create a real driver.
+/// By default, a `DrivableWidget` will create a TestDriver when it notices
+/// that a test is running.
+///
+/// But when we use `TestDrivableWidget` then we are running a test, but we
+/// want it to still create the real driver. Since we use the
+/// `TestDrivableWidget` as a container to test the real widget.
+///
+/// So this [TestRuntimeEnvironmentInfo] helps with that by saying the we
+/// are never in a test environment. This way the `TestDrivableWidget` will
+/// think it should create the real driver. Perfect :-D
 class TestRuntimeEnvironmentInfo implements RuntimeEnvironmentInfo {
   @override
   bool isRunningInTestEnvironment() {

--- a/widget_driver_test/lib/src/utils/test_widget_driver_provider.dart
+++ b/widget_driver_test/lib/src/utils/test_widget_driver_provider.dart
@@ -1,5 +1,8 @@
 import 'package:widget_driver/widget_driver.dart';
 
+/// This driver provider is used by the `TestDrivableWidget`
+/// and the helper extension on WidgetTester to make sure that
+/// the driver under test is created correctly.
 class TestWidgetDriverProvider<T extends WidgetDriver> extends WidgetDriverProvider<T> {
   final T Function(BuildContext context) _driverBuilder;
 

--- a/widget_driver_test/lib/src/utils/test_widget_driver_provider.dart
+++ b/widget_driver_test/lib/src/utils/test_widget_driver_provider.dart
@@ -1,0 +1,19 @@
+import 'package:widget_driver/widget_driver.dart';
+
+class TestWidgetDriverProvider<T extends WidgetDriver> extends WidgetDriverProvider<T> {
+  final T Function(BuildContext context) _driverBuilder;
+
+  TestWidgetDriverProvider({
+    required T Function(BuildContext context) driverBuilder,
+  }) : _driverBuilder = driverBuilder;
+
+  @override
+  T buildDriver(BuildContext context) {
+    return _driverBuilder(context);
+  }
+
+  @override
+  T buildTestDriver() {
+    throw UnimplementedError();
+  }
+}

--- a/widget_driver_test/lib/src/widget_tester_extension.dart
+++ b/widget_driver_test/lib/src/widget_tester_extension.dart
@@ -3,6 +3,7 @@ import 'package:widget_driver/widget_driver.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widget_driver_test.dart';
+import 'utils/test_drivable_widget.dart';
 
 typedef WidgetBuilder = Widget Function(Widget driverWidget);
 
@@ -18,7 +19,7 @@ extension Driver on WidgetTester {
   /// Optionally you can also provide a [parentWidgetBuilder], this is useful if your
   /// driver needs to resolve dependencies via the [BuildContext].
   /// If that is the case, then the [parentWidgetBuilder] should create a widget which includes
-  /// those depdendencies. E.g. if you are using the `Provider` package, then your code might look like this:
+  /// those dependencies. E.g. if you are using the `Provider` package, then your code might look like this:
   ///
   /// ```dart
   /// final driverTester = await tester.getDriverTester<LogInOutButtonDriver>(
@@ -38,34 +39,15 @@ extension Driver on WidgetTester {
     required T Function(BuildContext context) driverBuilder,
     WidgetBuilder? parentWidgetBuilder,
   }) async {
-    T? driver;
-    Widget driverWidget = _DriverContainerWidget<T>(
-      builder: (context) {
-        driver = driverBuilder(context);
-      },
+    TestDrivableWidget<T> drivableWidget = TestDrivableWidget<T>(
+      driverBuilder: driverBuilder,
     );
-    Widget widget = driverWidget;
+    Widget widget = drivableWidget;
     if (parentWidgetBuilder != null) {
-      widget = parentWidgetBuilder(driverWidget);
+      widget = parentWidgetBuilder(drivableWidget);
     }
     await pumpWidget(widget);
 
-    return DriverTester<T>(driver!, this);
-  }
-}
-
-class _DriverContainerWidget<T extends WidgetDriver> extends StatelessWidget {
-  final void Function(BuildContext) _driverBuilder;
-
-  const _DriverContainerWidget({
-    Key? key,
-    required void Function(BuildContext) builder,
-  })  : _driverBuilder = builder,
-        super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    _driverBuilder(context);
-    return const Placeholder();
+    return DriverTester<T>(drivableWidget.driver, this);
   }
 }

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_test
 description: Test helpers for WidgetDriver
-version: 0.0.1
+version: 0.0.2
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_test
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widget_driver: ^0.0.1
+  widget_driver: ^0.0.2
   mocktail: ^0.3.0
   meta: ^1.7.0
   test: ^1.16.0


### PR DESCRIPTION
## Description
There was a bug in the widget_driver_tests for the driverTest helper.
It didn't create the testable drivers correctly. So they were not really disposed when the widget went off the widget tree.

This change fixes this so that driver are loaded and disposed correctly by the test helper.

This is the second part needed to fix the remaining unit test in widget_driver.
After this PR has been merged, then I will deploy a new version of the `widget_driver_test`
and then in the upcoming later final PR I will tell `wdiget_driver` to use this new version of `widget_driver_test` and add the remaining unit tests.

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
