### PR TITLE
Adds new annotation to provide return values to future returning methods

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -10,7 +10,12 @@ PROJECT_FOLDERS=("widget_driver" "widget_driver_annotation" "widget_driver_gener
 function run_tests() {
     current_dir=$(pwd)
     cd $1
-    flutter test --coverage --no-pub --no-test-assets --no-track-widget-creation --no-sound-null-safety || exit $?
+    if [ $project_folder == "widget_driver_annotation" ]; then
+        # The widget_driver_annotation is a dart package, not flutter.
+        dart test --coverage coverage || exit $?
+    else
+        flutter test --coverage --no-pub --no-test-assets --no-track-widget-creation --no-sound-null-safety || exit $?
+    fi
     cd $current_dir
 }
 

--- a/widget_driver_annotation/CHANGELOG.md
+++ b/widget_driver_annotation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.0.3
+
+* Breaking change: Removes old annotation -> `Driver`, `DriverProperty`, `DriverAction`.  
+Replaces them with more descriptive annotations -> `GenerateTestDriver`, `TestDriverDefaultValue`.
+* Adds support for having annotations which generate code returning `Futures`  
+For that, use the new `TestDriverDefaultFutureValue`
+
 ## 0.0.1
 
 * Initial release.

--- a/widget_driver_annotation/CHANGELOG.md
+++ b/widget_driver_annotation/CHANGELOG.md
@@ -7,6 +7,10 @@ Replaces them with more descriptive annotations -> `GenerateTestDriver`, `TestDr
 * Adds support for having annotations which generate code returning `Futures`  
 For that, use the new `TestDriverDefaultFutureValue`
 
+## 0.0.2
+
+* Adds example markdown file for pub.dev to give basic information about how to use the annotations.
+
 ## 0.0.1
 
 * Initial release.

--- a/widget_driver_annotation/example/README.md
+++ b/widget_driver_annotation/example/README.md
@@ -1,13 +1,26 @@
 ## WidgetDriver annotation usage
 
 ```dart
-      @DriverProperty(1)
-      int get value => _counterService.value;
+@GenerateTestDriver()
+class CounterDriver extends WidgetDriver {
+    @TestDriverDefaultValue(1)
+    int get value => _counterService.value;
 
-      @DriverAction()
-      void increment() {
+    @TestDriverDefaultValue()
+    void increment() {
         _counterService.increment();
-      }
+    }
+
+    @TestDriverDefaultValue(false)
+    bool doSomething() {
+        return _counterService.doSomething();
+    }
+
+    @TestDriverDefaultFutureValue(1)
+    Future<int> incrementInTheFutureAndReturnValue() {
+        return _counterService.incrementInTheFutureAndReturnValue();
+    }
+}
 ```
 
 See the documentation for [widget_driver](https://github.com/bmw-tech/widget_driver/tree/master/widget_driver) to understand how these annotations work and how you can configure and use them.

--- a/widget_driver_annotation/lib/src/driver_annotations.dart
+++ b/widget_driver_annotation/lib/src/driver_annotations.dart
@@ -1,19 +1,88 @@
 /// Use this annotation on your `WidgetDriver` to generate
 /// the code for the `TestDriver` and the `DriverProvider`.
-class Driver {
-  const Driver();
+class GenerateTestDriver {
+  const GenerateTestDriver();
 }
 
-/// Use this annotation on your properties in the `WidgetDriver`
-/// to generate the hardcoded default values for the `TestDriver`.
-class DriverProperty<T> {
-  final T value;
-  const DriverProperty(this.value);
-}
-
-/// Use this annotation on your methods in the `WidgetDriver` to generate the
-/// hardcoded default methods with correct return values for the `TestDriver`.
-class DriverAction<T> {
+/// Use this annotation on properties/methods in your `Driver` to generate
+/// the hardcoded default test values which will be used by the `TestDriver`.
+/// Your `DrivableWidget` will then use these values from the `TestDriver`
+/// when it is created during testing.
+///
+/// ### Here is an example of how to use these:
+///
+/// ```dart
+/// @GenerateTestDriver()
+/// class RandomNumberWidgetDriver extends WidgetDriver {
+///     RandomNumberService _randomNumberService = ...;
+///     Localization _localization = ...;
+///
+///     @TestDriverDefaultValue(123)
+///     int get randomNumber => _randomNumberService.theRandomNumber;
+///
+///     @TestDriverDefaultValue('Get new random number')
+///     String get buttonText => _localization.getRandomNumberButtonText;
+///
+///     @TestDriverDefaultValue()
+///     void updateRandomNumber() {
+///         ...
+///     }
+/// }
+/// ```
+///
+/// This will generate the following `TestDriver`
+/// ```dart
+/// class _$RandomNumberWidgetDriver extends TestDriver implements CoffeeLibraryPageDriver {
+///     @override
+///     int get randomNumber => 123;
+///
+///     @override
+///     String get buttonText => 'Get new random number';
+///
+///     @override
+///     void updateRandomNumber() {}
+/// }
+/// ```
+class TestDriverDefaultValue<T> {
   final T? value;
-  const DriverAction([this.value]);
+  const TestDriverDefaultValue([this.value]);
+}
+
+/// Use this annotation on properties/methods which return `Futures` in your
+/// `Driver` to generate the hardcoded default test values which will be used
+/// by the `TestDriver`. Your `DrivableWidget` will then use these values from
+/// the `TestDriver` when it is created during testing.
+///
+/// ### Here is an example of how to use these:
+///
+/// ```dart
+/// @GenerateTestDriver()
+/// class RandomNumberWidgetDriver extends WidgetDriver {
+///     RandomNumberService _randomNumberService = ...;
+///
+///     @TestDriverDefaultFutureValue(123)
+///     Future<int> get randomNumber => _randomNumberService.theRandomNumberFuture;
+///
+///     @TestDriverDefaultFutureValue(false)
+///     Future<bool> updateRandomNumber() {
+///         ...
+///     }
+/// }
+/// ```
+///
+/// This will generate the following `TestDriver`
+/// ```dart
+/// class _$RandomNumberWidgetDriver extends TestDriver implements CoffeeLibraryPageDriver {
+///     @override
+///     Future<int> get randomNumber => Future.value(123);
+///
+///     @override
+///     Future<bool> updateRandomNumber() {
+///         return Future.value(false);
+///     }
+/// }
+/// ```
+class TestDriverDefaultFutureValue<T> {
+  final T? value;
+  const TestDriverDefaultFutureValue([this.value]);
 }

--- a/widget_driver_annotation/pubspec.yaml
+++ b/widget_driver_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_annotation
 description: Defines the annotations used by widget_driver and widget_driver_generator to create code for your WidgetDrivers
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_annotation
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 

--- a/widget_driver_annotation/test/dummy_test.dart
+++ b/widget_driver_annotation/test/dummy_test.dart
@@ -1,8 +1,0 @@
-import 'package:test/test.dart';
-
-void main() {
-  test('test dummy', () {
-    const foo = 1;
-    expect(foo, 1);
-  });
-}

--- a/widget_driver_annotation/test/generate_test_driver_test.dart
+++ b/widget_driver_annotation/test/generate_test_driver_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+import 'package:widget_driver_annotation/widget_driver_annotation.dart';
+
+import 'test_helpers/annotation_info_getter.dart';
+
+void main() {
+  test('`GenerateTestDriver` can be created as a const variable', () {
+    const generateTestDriver = GenerateTestDriver();
+    expect(generateTestDriver.runtimeType, GenerateTestDriver);
+  });
+
+  test('Can annotate a class with `GenerateTestDriver` and read out the annotation from the class', () {
+    final annotation = AnnotationInfoGetter.getClassAnnotation<GenerateTestDriver>(_TestClass);
+    expect(annotation, isNotNull);
+    expect(annotation.runtimeType, GenerateTestDriver);
+  });
+}
+
+/// Here we create a class and try to annotate it with the `GenerateTestDriver`.
+/// Then we use this in the unit tests and verify that we can read out this annotation from the class.
+@GenerateTestDriver()
+class _TestClass {}

--- a/widget_driver_annotation/test/test_driver_default_future_value_test.dart
+++ b/widget_driver_annotation/test/test_driver_default_future_value_test.dart
@@ -1,0 +1,42 @@
+import 'package:test/test.dart';
+import 'package:widget_driver_annotation/widget_driver_annotation.dart';
+
+import 'test_helpers/annotation_info_getter.dart';
+
+void main() {
+  test('`TestDriverDefaultFutureValue` can be created as a const variable', () {
+    const testDriverDefaultFutureValue = TestDriverDefaultFutureValue();
+    expect(testDriverDefaultFutureValue.runtimeType, TestDriverDefaultFutureValue);
+  });
+
+  test('Can create `TestDriverDefaultFutureValue` with no value (representing void)', () {
+    const testDriverDefaultFutureValue = TestDriverDefaultFutureValue();
+    expect(testDriverDefaultFutureValue.value, null);
+  });
+
+  test('Can create `TestDriverDefaultFutureValue` with some const values', () {
+    const boolTestDriverDefaultFutureValue = TestDriverDefaultFutureValue(false);
+    expect(boolTestDriverDefaultFutureValue.value, false);
+
+    const stringTestDriverDefaultFutureValue = TestDriverDefaultFutureValue('Some text');
+    expect(stringTestDriverDefaultFutureValue.value, 'Some text');
+  });
+
+  test('Can annotate a method with `TestDriverDefaultFutureValue` and read out the annotation from the method', () {
+    final testClass = _TestClass();
+    final annotation =
+        AnnotationInfoGetter.getMethodAnnotation<TestDriverDefaultFutureValue<String>>(testClass.someStringMethod);
+
+    expect(annotation, isNotNull);
+    expect(annotation!.value, 'Some default string');
+  });
+}
+
+/// Here we create a class and annotate a method with the `TestDriverDefaultFutureValue`.
+/// Then we use this in the unit tests and verify that we can read out this annotation.
+class _TestClass {
+  @TestDriverDefaultFutureValue('Some default string')
+  Future<String> someStringMethod() {
+    return Future.value('Some string');
+  }
+}

--- a/widget_driver_annotation/test/test_driver_default_value_test.dart
+++ b/widget_driver_annotation/test/test_driver_default_value_test.dart
@@ -1,0 +1,42 @@
+import 'package:test/test.dart';
+import 'package:widget_driver_annotation/widget_driver_annotation.dart';
+
+import 'test_helpers/annotation_info_getter.dart';
+
+void main() {
+  test('`TestDriverDefaultValue` can be created as a const variable', () {
+    const testDriverDefaultValue = TestDriverDefaultValue();
+    expect(testDriverDefaultValue.runtimeType, TestDriverDefaultValue);
+  });
+
+  test('Can create `TestDriverDefaultValue` with no value (representing void)', () {
+    const testDriverDefaultValue = TestDriverDefaultValue();
+    expect(testDriverDefaultValue.value, null);
+  });
+
+  test('Can create `TestDriverDefaultValue` with some const values', () {
+    const boolTestDriverDefaultValue = TestDriverDefaultValue(false);
+    expect(boolTestDriverDefaultValue.value, false);
+
+    const stringTestDriverDefaultValue = TestDriverDefaultValue('Some text');
+    expect(stringTestDriverDefaultValue.value, 'Some text');
+  });
+
+  test('Can annotate a method with `TestDriverDefaultValue` and read out the annotation from the method', () {
+    final testClass = _TestClass();
+    final annotation =
+        AnnotationInfoGetter.getMethodAnnotation<TestDriverDefaultValue<String>>(testClass.someStringMethod);
+
+    expect(annotation, isNotNull);
+    expect(annotation!.value, 'Some default string');
+  });
+}
+
+/// Here we create a class and annotate a method with the `TestDriverDefaultValue`.
+/// Then we use this in the unit tests and verify that we can read out this annotation.
+class _TestClass {
+  @TestDriverDefaultValue('Some default string')
+  String someStringMethod() {
+    return 'Some string';
+  }
+}

--- a/widget_driver_annotation/test/test_helpers/annotation_info_getter.dart
+++ b/widget_driver_annotation/test/test_helpers/annotation_info_getter.dart
@@ -1,0 +1,14 @@
+import 'dart:mirrors';
+
+/// This is a helper class which contains methods for
+/// reading out annotations from classes and methods.
+class AnnotationInfoGetter {
+  static T? getClassAnnotation<T>(Type type) {
+    return reflectClass(type).metadata.first.reflectee as T;
+  }
+
+  static T? getMethodAnnotation<T>(dynamic objectMethod) {
+    var methodMirror = (reflect(objectMethod) as ClosureMirror).function;
+    return methodMirror.metadata.first.reflectee as T;
+  }
+}


### PR DESCRIPTION
## Description
Adds a new annotations for handling `Future` return values.
And also refactors existing annotations and renames them to more descriptive names.
This is an API breaking change!
Solves issue #74 

**Background**
When your driver has a method which returns a future. Then you currently run into problem.
Since if you want to provide a default value using @DriverAction then the value which you pass in there, it needs to be a const value. Since the annotation needs to have a const constructor.

And you cannot out-of-the-box create a const-future.

**Solution**
We add a new annotation which you can use when your function is returning a future.
The new annotation is called: `TestDriverDefaultFutureValue` and into it you pass the return value of the future which you are returning. See this example for how you can use this:

```
@GenerateTestDriver
class CoffeeLibraryPageDriver extends WidgetDriver {
  @TestDriverDefaultFutureValue(false)
  Future<bool> getCoffees() async {
    ... // Some logic..
    return false;
  }
}
```

That would now generate this code:
```
class _$TestCoffeeLibraryPageDriver extends TestDriver
    implements CoffeeLibraryPageDriver {
  @override
  Future<bool> getCoffees() {
    return Future.value(false);
  }
}
```

## More info

This PR also removes the old existing annotations and replaces them with more descriptive annotations.
The new annotation used for the driver class to make sure it gets generated it `GenerateTestDriver`.
And then the two annotations for properties and actions are merged into one which is called: `TestDriverDefaultValue`

## Even More info
This is a multi step rocket.

1. First we update the annotations to have this new annotation.
2. Then we update the generator to generate that new code using this new annotation
3. Update the example app to showcase how to use this new annotation

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [x] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [x] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [x] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
