### PR TITLE
Lowers the min version for mockito

### DIFF
--- a/widget_driver/example/pubspec.yaml
+++ b/widget_driver/example/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.4
-  mocktail: ^0.3.0
+  mocktail: ^0.1.4
   widget_driver_test:
     path: ../../widget_driver_test
   build_runner:

--- a/widget_driver/pubspec.yaml
+++ b/widget_driver/pubspec.yaml
@@ -18,6 +18,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.4
-  mocktail: ^0.3.0
+  mocktail: ^0.1.4
 
 flutter:

--- a/widget_driver_test/CHANGELOG.md
+++ b/widget_driver_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.4
+
+* Updates the required version of mocktail.  
+The required version was lowered to enable more users to be able to install this package.
+
 ## 0.0.3
 
 * Adds example markdown file for pub.dev to give basic information about how to use the widget_driver_test.

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_test
 description: Contains helper classes/methods for DrivableWidgets, WidgetDrivers, helps with TestDrivers mocking
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_test
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widget_driver: ^0.0.2
-  mocktail: ^0.3.0
+  widget_driver: ^0.0.4
+  mocktail: ^0.1.4
   meta: ^1.7.0
   test: ^1.16.0
   flutter_test:


### PR DESCRIPTION
## Description
I had some issues when I tried to integrate widget_driver_tests into the bmw internal flutter app.
We had a hard coded dependency to mockito in other packages which was lower than the one which was specified in `widget_driver_test`. So I just lowered it here.. We have no real reason to have it higher.. We just mockito to create a help-mock-interface.. So no real business logic.

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
