### PR TITLE
Adds missing Changelog entry for widget_driver for v 0.0.4

### DIFF
--- a/widget_driver/CHANGELOG.md
+++ b/widget_driver/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+* Updates documentation to reflect the new driver annotation names.
+
 ## 0.0.3
 
 * Removes `FlowCoordinators` since it is currently not used. We will add this back if it ever becomes needed.


### PR DESCRIPTION
## Description
I forgot to update the Changelog last time I updated the widget_driver.
This PR adds the missing changelog entry

## Type of Change>

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [x] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
