### PR TITLE
Fix bug where a new TestDrivableWidget is ignored by element tree if one was already created

### DIFF
--- a/widget_driver_test/lib/src/utils/test_drivable_widget.dart
+++ b/widget_driver_test/lib/src/utils/test_drivable_widget.dart
@@ -12,10 +12,9 @@ class TestDrivableWidget<T extends WidgetDriver> extends DrivableWidget<T> {
   final T Function(BuildContext context) _driverBuilder;
 
   TestDrivableWidget({
-    Key? key,
     required T Function(BuildContext context) driverBuilder,
   })  : _driverBuilder = driverBuilder,
-        super(key: key, environmentInfo: TestRuntimeEnvironmentInfo());
+        super(key: UniqueKey(), environmentInfo: TestRuntimeEnvironmentInfo());
 
   @override
   Widget build(BuildContext context) {

--- a/widget_driver_test/lib/src/utils/test_drivable_widget.dart
+++ b/widget_driver_test/lib/src/utils/test_drivable_widget.dart
@@ -12,9 +12,10 @@ class TestDrivableWidget<T extends WidgetDriver> extends DrivableWidget<T> {
   final T Function(BuildContext context) _driverBuilder;
 
   TestDrivableWidget({
+    Key? key,
     required T Function(BuildContext context) driverBuilder,
   })  : _driverBuilder = driverBuilder,
-        super(key: UniqueKey(), environmentInfo: TestRuntimeEnvironmentInfo());
+        super(key: key, environmentInfo: TestRuntimeEnvironmentInfo());
 
   @override
   Widget build(BuildContext context) {

--- a/widget_driver_test/lib/src/widget_tester_extension.dart
+++ b/widget_driver_test/lib/src/widget_tester_extension.dart
@@ -40,6 +40,7 @@ extension Driver on WidgetTester {
     WidgetBuilder? parentWidgetBuilder,
   }) async {
     TestDrivableWidget<T> drivableWidget = TestDrivableWidget<T>(
+      key: UniqueKey(),
       driverBuilder: driverBuilder,
     );
     Widget widget = drivableWidget;


### PR DESCRIPTION
<!--
  Wohoo! 🥳 Thanks for contributing! The coding part is Done. Now lets get some reviews!
  Please provide a description and fill in the checklist to ensure that your PR can be accepted quickly.
-->

## Description
There was a bug with our testing framework that did not allow for a creation of multiple TestDrivableWidgets in one test. The reason was that the flutter element tree did not recognize the new widget as new and therefore reused the old one. This gives the TestDrivableWidget a unique key, thus always forcing the element tree to use the new widget.
## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
