### PR TITLE
Adds placeholder code for a helper method to get dependencies with fallback support

### DIFF
--- a/widget_driver/README.md
+++ b/widget_driver/README.md
@@ -551,6 +551,17 @@ Now this works fine when running the app normally. But when you run widget tests
 
 To get around this we have created a helper class called `DependencyProvider`. This class adds a small wrapper around the creation of your dependency and will automatically provide a test default value for you when running tests.  
 
+This is how you would use it:
+
+```dart
+Widget build(BuildContext context) {
+  return Provider(
+    create: _DependencyProvider().get(() => MyService(someStuffFromContext: context.read<SomeStuff>())),
+    child: child,
+  );
+}
+```
+
 Please see the documentation for [DependencyProvider](lib/src/dependency_provider.dart) for more information.
 
 ## Examples

--- a/widget_driver/README.md
+++ b/widget_driver/README.md
@@ -448,6 +448,25 @@ So please follow guideline two -> Put your business logic in the `Driver`, not i
 
 More about testing and the benefits are described [here](doc/testing.md)
 
+## Providing dependencies into the build context
+
+If you need to inject some dependencies into the BuildContext then a typical use case is that you create/resolve them in a build method of a widget. And then you use some state management tool like `Provider` to inject them into the widget tree. Like so:
+
+```dart
+Widget build(BuildContext context) {
+  return Provider(
+    create: MyService(someStuffFromContext: context.read<SomeStuff>()),
+    child: child,
+  );
+}
+```
+
+Now this works fine when running the app normally. But when you run widget tests, then any parent of this widget would need to provide a mocked version of `SomeStuff` into the build context, otherwise the `context.read<SomeStuff>()` would fail and throw an exception.
+
+To get around this we have created a helper class called `DependencyProvider`. This class adds a small wrapper around the creation of your dependency and will automatically provide a test default value for you when running tests.  
+
+Please see the documentation for [DependencyProvider](lib/src/dependency_provider.dart) for more information.
+
 ## Examples
 
 Please see this [example app](example) for inspiration on how to use `WidgetDrivers` in your app.  
@@ -462,7 +481,7 @@ But the application state should not be stored in the `Driver`! It is not the ow
 
 So the `Drivers` will need to access state somehow. [Here](https://docs.flutter.dev/development/data-and-backend/state-mgmt/options) is a list of recommended state management approaches. **BUT** just make sure to use these state management systems in the `Driver`.
 
-For e.g. if you choose to use [Provider](https://pub.dev/packages/provider), then don't use your `Provider` in the widgets. So don't use `context.watch<T>()`. Instead you then want to use the `Providers` in your `Driver`. See the [example app](example/) for inspiration on how to do this.
+For e.g. if you choose to use [Provider](https://pub.dev/packages/provider), then don't use your `Provider` in the widgets. So don't use `context.watch<T>()` in your widgets build method. Instead you then want to use the `Providers` in your `Driver`. See the [example app](example/) for inspiration on how to do this.
 
 ## Documentation
 

--- a/widget_driver/lib/src/dependency_provider.dart
+++ b/widget_driver/lib/src/dependency_provider.dart
@@ -1,52 +1,143 @@
-class MyTest {
-  static final _internalInstance = MyTest();
+import 'utils/runtime_environment_info.dart';
 
-  final map = <dynamic, dynamic>{};
-
-  static void register<T>(T Function() builder) {
-    _internalInstance.map[T] = builder;
-  }
-
-  static T? getRegistered<T>() {
-    final T Function()? valueBuilder = _internalInstance.map[T];
-    if (valueBuilder != null) {
-      return valueBuilder();
-    }
-    return null;
-  }
-}
-
+/// Use this class to create/resolve dependencies in your widgets.
+/// This class adds a safe way to create/resolve dependencies during testing where
+/// parent widgets are not forced to provide a mocked instance of your dependency.
+///
+/// The `DependencyProvider` will create the dependency object
+/// according to the provided builder when you are not running tests.
+///
+/// During testing the `DependencyProvider` will first try to create the dependency object using your builder,
+/// but if this fails and throws (because for example no parent widget registered the dependency),
+/// then the `DependencyProvider` will return the registered test default value.
+///
+/// This is how you use this in your widget where you provide dependencies:
+/// Step one: At the bottom of your widget class, create a subclass of `DependencyProvider` and implement the
+/// `registerTestDefaultFallbackValues` method. In this method you register the test default instance.
+/// This should be an empty implementation instance. Like a mock object.
+///
+/// ```dart
+/// class MyServiceProviderWidget extends StatelessWidget {
+///     ...
+/// }
+///
+/// class _DependencyProvider extends DependencyProvider {
+///     @override
+///     void registerTestDefaultFallbackValues() {
+///         registerTestDefaultBuilder<MyService>(() => TestDefaultMyService());
+///     }
+/// }
+///
+/// class TestDefaultMyService extends EmptyDefault implements TestDefaultMyService {}
+/// ```
+///
+/// And then you use this concrete version of `DependencyProvider` in your widget to create that instance.
+/// Like this:
+///
+/// ```dart
+/// class MyServiceProviderWidget extends StatelessWidget {
+///     ...
+///     @override
+///     Widget build(BuildContext context) {
+///         return Provider(
+///             create: _DependencyProvider().get(() => MyService(someStuffFromContext: context.read<SomeStuff>())),
+///             child: child,
+///         );
+///     }
+/// }
+/// ```
+///
+/// Now when you run this normally as a flutter app, then the real `MyService` will be created.
+/// And it will try to real `SomeStuff` out of the build context.
+/// And when you run this during tests and you registered some mock version of `SomeStuff` in the buildContext
+/// then that will be used.
+///
+/// BUT: if you run this during tests, and you never registered any type for `SomeStuff` in the buildContext then
+/// normally this would break your test build and throw an exception. But in this case it will still run.
+/// It just returns the empty test default instance of your `MyService`.
+///
+/// So when you run any parent widget test then they do not need to be aware of your needed dependency!
 abstract class DependencyProvider {
+  final RuntimeEnvironmentInfo _environmentInfo;
+
   bool _didCallSetupTestValues = false;
 
+  final _defaultTestValueMap = <dynamic, dynamic>{};
+
+  DependencyProvider({
+    RuntimeEnvironmentInfo? environmentInfo,
+  }) : _environmentInfo = environmentInfo ?? RuntimeEnvironmentInfo();
+
+  /// When running normally (outside of tests) this returns the instance which your builder returns.
+  ///
+  /// During tests, this tries to return the instance which your builder returns.
+  /// But if this fails for some reason (e.g. you did not provide a mock version of that type),
+  /// then this method returns the registered test default value for the given type.
+  ///
+  /// If you did not register a test default builder for the given type,
+  /// then this method throws the exception which was thrown by the builder.
   T get<T>(T Function() builder) {
     try {
       final T value = builder();
       return value;
     } catch (error) {
-      // No dependency could be loaded using normal approach.
+      // No dependency could be loaded from the provided builder.
+      // Probably since the builder tries to access a dependency from the BuildContext which was not there.
+      // This is a common issue when parent widgets renders child widgets which tries to resolve dependencies.
 
-      if (!_didCallSetupTestValues) {
-        setupTestDefaultFallbackValues();
-        _didCallSetupTestValues = true;
-      }
-
-      final defaultTestValueBuilder = MyTest.getRegistered<T>();
-      if (defaultTestValueBuilder != null) {
-        return defaultTestValueBuilder;
+      // If we are running tests, then try to return the test default value
+      if (_environmentInfo.isRunningInTestEnvironment()) {
+        final testDefaultInstance = _tryToGetTestDefaultInstance();
+        if (testDefaultInstance != null) {
+          return testDefaultInstance;
+        } else {
+          rethrow;
+        }
       } else {
         rethrow;
       }
     }
   }
 
-  void setupTestDefaultFallbackValues();
-}
+  /// Override this method to register all the test default values which you need.
+  ///
+  /// For example if you want to get the dependencies for 2 types: `MyService` and `ThemeData`
+  /// then you would add this implementation to your override:
+  ///
+  /// ```dart
+  /// class _DependencyProvider extends DependencyProvider {
+  ///     @override
+  ///     void registerTestDefaultFallbackValues() {
+  ///         registerTestDefaultBuilder<MyService>(() => TestDefaultMyService());
+  ///         registerTestDefaultBuilder<ThemeData>(() => TestDefaultThemeData());
+  ///     }
+  /// }
+  /// ```
+  ///
+  /// where the `TestDefaultMyService` and `TestDefaultThemeData` are some empty/mock-like fake implementations.
+  void registerTestDefaultFallbackValues();
 
-class _DependencyProvider extends DependencyProvider {
-  @override
-  void setupTestDefaultFallbackValues() {
-    MyTest.register<MaterialColor>(() => Colors.green);
-    MyTest.register<int>(() => 33333);
+  /// Call this to register a builder which creates a test default instance for a given type.
+  /// This builder/created-instance is used in testing when the normal
+  /// `DependencyProvider-get` method fails to create your dependency.
+  void registerTestDefaultBuilder<T>(T Function() builder) {
+    _defaultTestValueMap[T] = builder;
+  }
+
+  T? _tryToGetTestDefaultInstance<T>() {
+    if (!_didCallSetupTestValues) {
+      registerTestDefaultFallbackValues();
+      _didCallSetupTestValues = true;
+    }
+
+    return _getRegisteredTestDefaultInstance<T>();
+  }
+
+  T? _getRegisteredTestDefaultInstance<T>() {
+    final T Function()? valueBuilder = _defaultTestValueMap[T];
+    if (valueBuilder != null) {
+      return valueBuilder();
+    }
+    return null;
   }
 }

--- a/widget_driver/lib/src/dependency_provider.dart
+++ b/widget_driver/lib/src/dependency_provider.dart
@@ -87,7 +87,7 @@ abstract class DependencyProvider {
 
       // If we are running tests, then try to return the test default value
       if (_environmentInfo.isRunningInTestEnvironment()) {
-        final testDefaultInstance = _tryToGetTestDefaultInstance();
+        final testDefaultInstance = _tryToGetTestDefaultInstance<T>();
         if (testDefaultInstance != null) {
           return testDefaultInstance;
         } else {

--- a/widget_driver/lib/src/dependency_provider.dart
+++ b/widget_driver/lib/src/dependency_provider.dart
@@ -1,0 +1,52 @@
+class MyTest {
+  static final _internalInstance = MyTest();
+
+  final map = <dynamic, dynamic>{};
+
+  static void register<T>(T Function() builder) {
+    _internalInstance.map[T] = builder;
+  }
+
+  static T? getRegistered<T>() {
+    final T Function()? valueBuilder = _internalInstance.map[T];
+    if (valueBuilder != null) {
+      return valueBuilder();
+    }
+    return null;
+  }
+}
+
+abstract class DependencyProvider {
+  bool _didCallSetupTestValues = false;
+
+  T get<T>(T Function() builder) {
+    try {
+      final T value = builder();
+      return value;
+    } catch (error) {
+      // No dependency could be loaded using normal approach.
+
+      if (!_didCallSetupTestValues) {
+        setupTestDefaultFallbackValues();
+        _didCallSetupTestValues = true;
+      }
+
+      final defaultTestValueBuilder = MyTest.getRegistered<T>();
+      if (defaultTestValueBuilder != null) {
+        return defaultTestValueBuilder;
+      } else {
+        rethrow;
+      }
+    }
+  }
+
+  void setupTestDefaultFallbackValues();
+}
+
+class _DependencyProvider extends DependencyProvider {
+  @override
+  void setupTestDefaultFallbackValues() {
+    MyTest.register<MaterialColor>(() => Colors.green);
+    MyTest.register<int>(() => 33333);
+  }
+}

--- a/widget_driver/lib/src/dependency_provider.dart
+++ b/widget_driver/lib/src/dependency_provider.dart
@@ -2,7 +2,7 @@ import 'utils/runtime_environment_info.dart';
 
 /// Use this class to create/resolve dependencies in your widgets.
 /// This class adds a safe way to create/resolve dependencies during testing where
-/// parent widgets are not forced to provide a mocked instance of your dependency.
+/// parent widgets are not forced to provide a mocked instances of your dependencies.
 ///
 /// The `DependencyProvider` will create the dependency object
 /// according to the provided builder when you are not running tests.
@@ -13,14 +13,16 @@ import 'utils/runtime_environment_info.dart';
 ///
 /// This is how you use this in your widget where you provide dependencies:
 /// Step one: At the bottom of your widget class, create a subclass of `DependencyProvider` and implement the
-/// `registerTestDefaultFallbackValues` method. In this method you register the test default instance.
+/// `registerTestDefaultFallbackValues` method. In this method you register the test default instances.
 /// This should be an empty implementation instance. Like a mock object.
+/// You typically would only have one concrete implementation of `DependencyProvider` per widget where you use it.
 ///
 /// ```dart
 /// class MyServiceProviderWidget extends StatelessWidget {
 ///     ...
 /// }
 ///
+/// // Here we create the concrete implementation of `DependencyProvider`
 /// class _DependencyProvider extends DependencyProvider {
 ///     @override
 ///     void registerTestDefaultFallbackValues() {
@@ -48,13 +50,14 @@ import 'utils/runtime_environment_info.dart';
 /// ```
 ///
 /// Now when you run this normally as a flutter app, then the real `MyService` will be created.
-/// And it will try to real `SomeStuff` out of the build context.
-/// And when you run this during tests and you registered some mock version of `SomeStuff` in the buildContext
-/// then that will be used.
+/// And it will try to get the real `SomeStuff` instance out of the build context.
+/// Should you want to provide a mocked version of `SomeStuff` during testing, then you can just simply
+/// provide that object in the buildContext, like you would previously and that one will be used.
 ///
-/// BUT: if you run this during tests, and you never registered any type for `SomeStuff` in the buildContext then
-/// normally this would break your test build and throw an exception. But in this case it will still run.
-/// It just returns the empty test default instance of your `MyService`.
+/// BUT: if you run this during tests, and you never registered any type for `SomeStuff` in the buildContext.
+/// Normally, this would break your test build and throw an exception. In this case however, we will default back
+/// to your test default instance of your `MyService`, provided in the registerTestDefaultBuilder() method.
+/// Thereby taking away one more thing to consider/remember when writing tests.
 ///
 /// So when you run any parent widget test then they do not need to be aware of your needed dependency!
 abstract class DependencyProvider {

--- a/widget_driver/lib/src/utils/empty_default.dart
+++ b/widget_driver/lib/src/utils/empty_default.dart
@@ -1,0 +1,30 @@
+/// Extend this class when you need to provide a TestDefault implementation for a given type.
+///
+/// Say for example that you have some service called `AuthService` which might look something like this:
+///
+/// ```dart
+/// class AuthService {
+///     bool get isLoggedIn => ...
+///
+///     void logout() { ... }
+/// }
+/// ```
+///
+/// If you want to create a version of this service with no real code which you can use in your testDriver
+/// you have to create some class which implements this interface.
+/// Now if you just create some class which implements the `AuthService`
+/// then you are also forced to override the complete interface of the `AuthService`.
+///
+/// To get around this you can just extend the [EmptyDefault]. This way you are not force to override any interface.
+/// And if you want/need a default implementation for a given interface, then you can just choose to implement that.
+/// Like so:
+///
+/// ```dart
+/// class TestDefaultAuthService extends EmptyDefault implements AuthService {}
+/// ```
+abstract class EmptyDefault {
+  const EmptyDefault();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {}
+}

--- a/widget_driver/lib/src/utils/test_driver_empty_default_implementation.dart
+++ b/widget_driver/lib/src/utils/test_driver_empty_default_implementation.dart
@@ -1,7 +1,0 @@
-/// Extend this class for TestDriverDefaultValues that you don't want to implement
-abstract class EmptyDefault {
-  const EmptyDefault();
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) {}
-}

--- a/widget_driver/lib/widget_driver.dart
+++ b/widget_driver/lib/widget_driver.dart
@@ -5,6 +5,7 @@ export 'src/widget_driver_provider.dart';
 export 'src/drivable_widget.dart';
 export 'src/mock_driver_provider.dart';
 export 'src/utils/runtime_environment_info.dart';
-export 'src/utils/test_driver_empty_default_implementation.dart';
+export 'src/utils/empty_default.dart';
+export 'src/dependency_provider.dart';
 
 export 'package:widget_driver_annotation/widget_driver_annotation.dart';

--- a/widget_driver/test/dependency_provider_test.dart
+++ b/widget_driver/test/dependency_provider_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widget_driver/widget_driver.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockRuntimeEnvironmentInfo extends Mock implements RuntimeEnvironmentInfo {}
+
+// ignore_for_file: prefer_function_declarations_over_variables
+
+void main() {
+  group('DependencyProvider:', () {
+    late _MockRuntimeEnvironmentInfo _mockRuntimeEnvironmentInfo;
+    late DependencyProvider sut;
+
+    setUp(() {
+      _mockRuntimeEnvironmentInfo = _MockRuntimeEnvironmentInfo();
+    });
+
+    group('When not running tests:', () {
+      setUp(() {
+        when(() => _mockRuntimeEnvironmentInfo.isRunningInTestEnvironment()).thenReturn(false);
+      });
+      group('When no TestDefault is registered:', () {
+        setUp(() {
+          sut = _TestingDependencyProviderWithoutTestDefaults(environmentInfo: _mockRuntimeEnvironmentInfo);
+        });
+
+        test('Returns dependency from builder when builder does not throw.', () {
+          const expectedStringDependency = 'Some string I want to inject';
+          final String Function() stringBuilder = () {
+            return expectedStringDependency;
+          };
+
+          final myStringDependency = sut.get(() => stringBuilder());
+
+          expect(myStringDependency, equals(expectedStringDependency));
+        });
+
+        test('Throws original exception when builder does throw.', () {
+          final expectedException = Exception('Dependency could not be created');
+          final String Function() stringBuilder = () {
+            throw expectedException;
+          };
+
+          try {
+            sut.get(() => stringBuilder());
+          } catch (error) {
+            expect(error, equals(expectedException));
+          }
+        });
+      });
+
+      group('When TestDefault is registered:', () {
+        setUp(() {
+          sut = _TestingDependencyProviderWithTestDefaults(environmentInfo: _mockRuntimeEnvironmentInfo);
+        });
+
+        test('Returns dependency from builder when builder does not throw.', () {
+          const expectedStringDependency = 'Some string I want to inject';
+          final String Function() stringBuilder = () {
+            return expectedStringDependency;
+          };
+
+          final myStringDependency = sut.get(() => stringBuilder());
+
+          expect(myStringDependency, equals(expectedStringDependency));
+        });
+
+        test('Throws original exception when builder does throw.', () {
+          final expectedException = Exception('Dependency could not be created');
+          final String Function() stringBuilder = () {
+            throw expectedException;
+          };
+
+          try {
+            sut.get(() => stringBuilder());
+          } catch (error) {
+            expect(error, equals(expectedException));
+          }
+        });
+      });
+    });
+
+    group('When running tests:', () {
+      setUp(() {
+        when(() => _mockRuntimeEnvironmentInfo.isRunningInTestEnvironment()).thenReturn(true);
+      });
+      group('When no TestDefault is registered:', () {
+        setUp(() {
+          sut = _TestingDependencyProviderWithoutTestDefaults(environmentInfo: _mockRuntimeEnvironmentInfo);
+        });
+
+        test('Returns dependency from builder when builder does not throw.', () {
+          const expectedStringDependency = 'Some string I want to inject';
+          final String Function() stringBuilder = () {
+            return expectedStringDependency;
+          };
+
+          final myStringDependency = sut.get(() => stringBuilder());
+
+          expect(myStringDependency, equals(expectedStringDependency));
+        });
+
+        test('Throws original exception when builder does throw.', () {
+          final expectedException = Exception('Dependency could not be created');
+          final String Function() stringBuilder = () {
+            throw expectedException;
+          };
+
+          try {
+            sut.get(() => stringBuilder());
+          } catch (error) {
+            expect(error, equals(expectedException));
+          }
+        });
+      });
+
+      group('When TestDefault is registered:', () {
+        setUp(() {
+          sut = _TestingDependencyProviderWithTestDefaults(environmentInfo: _mockRuntimeEnvironmentInfo);
+        });
+
+        test('Returns dependency from builder when builder does not throw.', () {
+          const expectedStringDependency = 'Some string I want to inject';
+          final String Function() stringBuilder = () {
+            return expectedStringDependency;
+          };
+
+          final myStringDependency = sut.get(() => stringBuilder());
+
+          expect(myStringDependency, equals(expectedStringDependency));
+        });
+
+        test('Returns TestDefault when builder does throw.', () {
+          final String Function() stringBuilder = () {
+            throw Exception('Dependency could not be created');
+          };
+
+          final myStringDependency = sut.get(() => stringBuilder());
+
+          expect(myStringDependency, equals('TestDefaultString'));
+        });
+      });
+    });
+  });
+}
+
+class _TestingDependencyProviderWithoutTestDefaults extends DependencyProvider {
+  _TestingDependencyProviderWithoutTestDefaults({
+    RuntimeEnvironmentInfo? environmentInfo,
+  }) : super(environmentInfo: environmentInfo);
+
+  @override
+  void registerTestDefaultFallbackValues() {}
+}
+
+class _TestingDependencyProviderWithTestDefaults extends DependencyProvider {
+  _TestingDependencyProviderWithTestDefaults({
+    RuntimeEnvironmentInfo? environmentInfo,
+  }) : super(environmentInfo: environmentInfo);
+
+  @override
+  void registerTestDefaultFallbackValues() {
+    registerTestDefaultBuilder<String>(() => 'TestDefaultString');
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a helper class which you can use if you need to inject a dependency into the BuildContext from a normal non-drivable widget.

**Why is this needed?**
If you try to create/resolve a dependency in a build method of a normal widget, that means that any parent widget will also create that dependency when that parent widget is tested..
So then that parent widget needs to provide mock data for all dependencies which that dependency needs..

The fix for this would be to use a driver.. and the create the dependency in the driver..
But if you have a small widget which has no view logic, it only provides dependnecies, then it is quite a overhead to create a driver for this..

**Solution**
We now offer a `DependencyProvider` which you can use in your normal widgets to create/resolve dependencies.. 
And then inject these dependencies into a build context.

The `DependencyProvider` will help you out when your widget is running under tests..
During testing the `DependencyProvider` will try to create the real instance.. It might work (for example, it could be that someone above you provided a mock version already). Then that will be used..

But if no one provided the mock daata.. then instead of crashing the test, then the `DependencyProvider` will return a TestDefault instance.. with no implementation..

**Here is an example of how to use:**
```dart
class NotLoggedInDependencyInjector extends StatelessWidget {
  final Widget child;

  const NotLoggedInDependencyInjector({Key? key, required this.child}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Provider(
      // Here we are seeing how this `_DependencyProvider` is used.. 
      // Now any parent widget can safely use this widget in tests
      // And any child of this widget has now access to a `CreateUserService`
      create: (_) => _DependencyProvider().get(() => CreateUserService(locator: context.read)),
      child: child,
    );
  }
}

// We need to create our own type which inherits from `DependencyProvider`
class _DependencyProvider extends DependencyProvider {
  @override
  void registerTestDefaultFallbackValues() {
    // Here we provide the TestDefault values which we want to support
    registerTestDefaultBuilder<CreateUserService>(() => TestDefaultCreateUserService());
  }
}

// Here we create the TestDefault type which we might need..  
class TestDefaultCreateUserService extends EmptyDefault implements CreateUserService {}
```


**Updates to the Example app using this new logic**
The PR which updates the Example app will come as soon as this PR is merged and deployed.. 
Since the example app depends on the widget driver deployed to pub.dev



## Type of Change

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
