### PR TITLE
Updates version of WidgetDriver to deploy new version with DependencyProvider

### DIFF
--- a/widget_driver/CHANGELOG.md
+++ b/widget_driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.0.8
+
+* Adds a new helper class `DependencyProvider` to support with creating/resolving dependencies when needed directly into the widget.
+
 ## 0.0.7
 
 * Fixes issues with ignoring of state changes

--- a/widget_driver/pubspec.yaml
+++ b/widget_driver/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver
 description: A Flutter presentation layer framework, which will clean up your widget code and make your widgets testable without a need for thousands of mock objects. Let's go driving!
-version: 0.0.7
+version: 0.0.8
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 


### PR DESCRIPTION
## Description

I added the new `DependencyProvider` class but I forgot to bump the version number..
So I cannot deploy a new version to pub.dev which has that new version.

Here is the PR which bumps it 😄 

## Type of Change

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
