### PR TITLE
Updates example app with showcase for injecting a dependency in widget using DependencyProvider

### DIFF
--- a/widget_driver/example/lib/api_client/api_client.dart
+++ b/widget_driver/example/lib/api_client/api_client.dart
@@ -1,0 +1,5 @@
+class ApiClient {
+  Future<void> createUser({required String name}) async {
+    await Future.delayed(const Duration(seconds: 1));
+  }
+}

--- a/widget_driver/example/lib/coordinator/coordinator.dart
+++ b/widget_driver/example/lib/coordinator/coordinator.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class Coordinator {
+  void pushMaterialPageRoute({
+    required BuildContext context,
+    required Widget Function(BuildContext context) builder,
+  }) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: builder,
+      ),
+    );
+  }
+
+  void pop({required BuildContext context}) {
+    Navigator.pop(context);
+  }
+}

--- a/widget_driver/example/lib/dependency_injection_manager.dart
+++ b/widget_driver/example/lib/dependency_injection_manager.dart
@@ -1,5 +1,6 @@
 import 'package:get_it/get_it.dart';
 
+import 'api_client/api_client.dart';
 import 'services/services.dart';
 
 class DependencyInjectionManager {
@@ -7,5 +8,6 @@ class DependencyInjectionManager {
     GetIt.I.registerLazySingleton<CoffeeConsumptionService>(() => CoffeeConsumptionService());
     GetIt.I.registerLazySingleton<CoffeeImageService>(() => CoffeeImageService());
     GetIt.I.registerLazySingleton<CoffeeService>(() => CoffeeService());
+    GetIt.I.registerLazySingleton<ApiClient>(() => ApiClient());
   }
 }

--- a/widget_driver/example/lib/localization/localization.dart
+++ b/widget_driver/example/lib/localization/localization.dart
@@ -6,6 +6,11 @@ class Localization {
   final String logIn = 'Log in';
   final String logOut = 'Log out';
 
+  final String createUsernameInputPlaceholder = 'Enter your desired username';
+  final String createUsernameInputNotValid = 'The username is not valid. Please try a new one';
+  final String registerNewAccount = 'Register a new account';
+  final String registerAndLogIn = 'Register and log in';
+
   final String consumedCoffees = 'Consumed coffees';
   final String consumeCoffeeQuick = 'Consume coffee quick';
   final String consumeCoffeeSlow = 'Consume coffee slowly';

--- a/widget_driver/example/lib/services/create_user_service.dart
+++ b/widget_driver/example/lib/services/create_user_service.dart
@@ -1,0 +1,26 @@
+import 'package:get_it/get_it.dart';
+import 'package:provider/provider.dart';
+
+import '../api_client/api_client.dart';
+import 'auth_service.dart';
+
+class CreateUserService {
+  final AuthService _authService;
+  final ApiClient _apiClient;
+
+  CreateUserService({
+    required Locator locator,
+    AuthService? authService,
+    ApiClient? apiClient,
+  })  : _authService = authService ?? locator<AuthService>(),
+        _apiClient = apiClient ?? GetIt.I.get<ApiClient>();
+
+  Future<void> createUserAndLogin(String name) async {
+    await _apiClient.createUser(name: name);
+    _authService.logIn();
+  }
+
+  bool isUserValidName(String name) {
+    return name.isNotEmpty;
+  }
+}

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:widget_driver/widget_driver.dart';
 
 import 'coffee_community_page_driver.dart';
+import 'not_logged_in/not_logged_in_dependency_injector.dart';
 
 class CoffeeCommunityPage extends DrivableWidget<CoffeeCommunityPageDriver> {
   CoffeeCommunityPage({Key? key}) : super(key: key);
@@ -13,7 +14,9 @@ class CoffeeCommunityPage extends DrivableWidget<CoffeeCommunityPageDriver> {
     if (driver.isLoggedIn) {
       return CoffeeLibraryPage();
     } else {
-      return NotLoggedInPage();
+      return NotLoggedInDependencyInjector(
+        child: NotLoggedInPage(),
+      );
     }
   }
 

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_dependency_injector.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_dependency_injector.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import '../../../services/create_user_service.dart';
+
+class NotLoggedInDependencyInjector extends StatelessWidget {
+  final Widget child;
+
+  const NotLoggedInDependencyInjector({Key? key, required this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Provider(
+      create: (_) => _DependencyProvider().get(() => CreateUserService(locator: context.read)),
+      child: child,
+    );
+  }
+}
+
+class _DependencyProvider extends DependencyProvider {
+  @override
+  void registerTestDefaultFallbackValues() {
+    registerTestDefaultBuilder<CreateUserService>(() => TestDefaultCreateUserService());
+  }
+}
+
+class TestDefaultCreateUserService extends EmptyDefault implements CreateUserService {}

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page.dart
@@ -8,7 +8,19 @@ class NotLoggedInPage extends DrivableWidget<NotLoggedInPageDriver> {
 
   @override
   Widget build(BuildContext context) {
-    return Center(child: Text(driver.notLoggedInText));
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Text(driver.notLoggedInText),
+        ),
+        ElevatedButton(
+          onPressed: () => driver.registerNewAccountTapped(context),
+          child: Text(driver.registerNewAccountButtonText),
+        ),
+      ],
+    );
   }
 
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.dart
@@ -1,6 +1,9 @@
+import 'package:example/services/create_user_service.dart';
+import 'package:example/widgets/coffee_community/not_logged_in/register_account/register_account_page.dart';
 import 'package:provider/provider.dart';
 import 'package:widget_driver/widget_driver.dart';
 
+import '../../../coordinator/coordinator.dart';
 import '../../../localization/localization.dart';
 
 part 'not_logged_in_page_driver.g.dart';
@@ -8,11 +11,32 @@ part 'not_logged_in_page_driver.g.dart';
 @GenerateTestDriver()
 class NotLoggedInPageDriver extends WidgetDriver {
   final Locator _locator;
+  final Coordinator _coordinator;
 
-  NotLoggedInPageDriver(BuildContext context)
-      : _locator = context.read,
+  NotLoggedInPageDriver(
+    BuildContext context, {
+    Localization? localization,
+    Coordinator? coordinator,
+  })  : _locator = context.read,
+        _coordinator = coordinator ?? Coordinator(),
         super(context);
 
   @TestDriverDefaultValue('Not logged in')
   String get notLoggedInText => _locator<Localization>().notLoggedIn;
+
+  @TestDriverDefaultValue('Register a new account')
+  String get registerNewAccountButtonText => _locator<Localization>().registerNewAccount;
+
+  @TestDriverDefaultValue()
+  void registerNewAccountTapped(BuildContext context) {
+    _coordinator.pushMaterialPageRoute(
+      context: context,
+      builder: (_) {
+        return Provider.value(
+          value: context.watch<CreateUserService>(),
+          child: RegisterAccountPage(),
+        );
+      },
+    );
+  }
 }

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
@@ -13,6 +13,12 @@ part of 'not_logged_in_page_driver.dart';
 class _$TestNotLoggedInPageDriver extends TestDriver implements NotLoggedInPageDriver {
   @override
   String get notLoggedInText => 'Not logged in';
+
+  @override
+  String get registerNewAccountButtonText => 'Register a new account';
+
+  @override
+  void registerNewAccountTapped(BuildContext context) {}
 }
 
 class $NotLoggedInPageDriverProvider extends WidgetDriverProvider<NotLoggedInPageDriver> {

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import 'register_account_page_driver.dart';
+
+class RegisterAccountPage extends DrivableWidget<RegisterAccountPageDriver> {
+  RegisterAccountPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(driver.pageTitle),
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: TextFormField(
+              decoration: InputDecoration(
+                  border: const UnderlineInputBorder(),
+                  labelText: driver.usernameTextFieldPlaceholder,
+                  errorText: driver.usernameInputError),
+              onChanged: driver.usernameInputChanged,
+            ),
+          ),
+          ElevatedButton(
+            onPressed: (() => driver.tappedRegister(context)),
+            child: driver.registerIsLoading
+                ? const Padding(
+                    padding: EdgeInsets.all(8.0),
+                    child: CircularProgressIndicator(strokeWidth: 3, color: Colors.white),
+                  )
+                : Text(driver.registerButtonText),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  WidgetDriverProvider<RegisterAccountPageDriver> get driverProvider => $RegisterAccountPageDriverProvider();
+}

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.dart
@@ -1,0 +1,84 @@
+import 'package:provider/provider.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import '../../../../coordinator/coordinator.dart';
+import '../../../../localization/localization.dart';
+import '../../../../services/create_user_service.dart';
+
+part 'register_account_page_driver.g.dart';
+
+@GenerateTestDriver()
+class RegisterAccountPageDriver extends WidgetDriver {
+  final Localization _localization;
+  final CreateUserService _createUserService;
+  final Coordinator _coordinator;
+
+  String _currentUsername = '';
+  String? _usernameInputError;
+  bool _registerIsLoading = false;
+
+  RegisterAccountPageDriver(
+    BuildContext context, {
+    Localization? localization,
+    CreateUserService? createUserService,
+    Coordinator? coordinator,
+  })  : _localization = context.read<Localization>(),
+        _createUserService = createUserService ?? context.read<CreateUserService>(),
+        _coordinator = coordinator ?? Coordinator(),
+        super(context);
+
+  @TestDriverDefaultValue('Register new account')
+  String get pageTitle => _localization.registerNewAccount;
+
+  @TestDriverDefaultValue('Enter your desired username')
+  String get usernameTextFieldPlaceholder => _localization.createUsernameInputPlaceholder;
+
+  @TestDriverDefaultValue(null)
+  String? get usernameInputError => _usernameInputError;
+
+  @TestDriverDefaultValue('Register and log in')
+  String get registerButtonText => _localization.registerAndLogIn;
+
+  @TestDriverDefaultValue(false)
+  bool get registerIsLoading => _registerIsLoading;
+
+  @TestDriverDefaultValue()
+  void usernameInputChanged(String inputName) {
+    _currentUsername = inputName;
+    _validateUsernameInput();
+  }
+
+  @TestDriverDefaultFutureValue()
+  Future<void> tappedRegister(BuildContext context) async {
+    if (_createUserService.isUserValidName(_currentUsername)) {
+      _setRegisterLoading(true);
+      await _createUserService.createUserAndLogin(_currentUsername);
+      _setRegisterLoading(false);
+      _coordinator.pop(context: context);
+    } else {
+      _validateUsernameInput();
+    }
+  }
+
+  void _validateUsernameInput() {
+    final wasShowingInputError = _isShowingInputError();
+    if (_createUserService.isUserValidName(_currentUsername)) {
+      _usernameInputError = null;
+    } else {
+      _usernameInputError = _localization.createUsernameInputNotValid;
+    }
+
+    if (wasShowingInputError != _isShowingInputError()) {
+      notifyWidget();
+    }
+  }
+
+  bool _isShowingInputError() {
+    return _usernameInputError != null;
+  }
+
+  void _setRegisterLoading(bool isLoading) {
+    _registerIsLoading = isLoading;
+    notifyWidget();
+  }
+}

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
@@ -1,0 +1,40 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'register_account_page_driver.dart';
+
+// **************************************************************************
+// WidgetDriverGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+
+// This file was generated with widget_driver_generator version: 1.0.0+1
+
+class _$TestRegisterAccountPageDriver extends TestDriver implements RegisterAccountPageDriver {
+  @override
+  String get pageTitle => 'Register new account';
+
+  @override
+  String get usernameTextFieldPlaceholder => 'Enter your desired username';
+
+  @override
+  String? get usernameInputError => null;
+
+  @override
+  void usernameInputChanged(String inputName) {}
+
+  @override
+  Future<void> tappedRegister(BuildContext context) async {}
+}
+
+class $RegisterAccountPageDriverProvider extends WidgetDriverProvider<RegisterAccountPageDriver> {
+  @override
+  RegisterAccountPageDriver buildDriver(BuildContext context) {
+    return RegisterAccountPageDriver(context);
+  }
+
+  @override
+  RegisterAccountPageDriver buildTestDriver() {
+    return _$TestRegisterAccountPageDriver();
+  }
+}

--- a/widget_driver/example/pubspec.yaml
+++ b/widget_driver/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  widget_driver: ^0.0.6
+  widget_driver: ^0.0.8
   meta: ^1.7.0
   get_it: ^7.2.0
   provider: ^6.0.4


### PR DESCRIPTION
## Description
WidgetDriver now contains a helper class for creating a Dependency in a widget.
This is useful when you need to inject a dependency into the buildContext from a widget.
So that child widgets can have access to the same dependency.

This PR updates the example app to show case how this can be used.
For demonstration purposes it creates some "fake" apiClients and userService and a registration flow.
Then the userService is injected into the registration flow using this new DependencyProvider approach.

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [x] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping

## GIF

This is how the new example app looks like (which uses DependencyProvider)
![Simulator Screen Recording - iPhone 14 Pro - 2023-03-02 at 08 57 49](https://user-images.githubusercontent.com/59053438/223104638-f4d4241a-4809-439e-ade9-ba4620f2ec30.gif)

