### PR TITLE
Updates example app to use latest widget driver 0.1.0 api

### DIFF
--- a/widget_driver/example/lib/models/consumed_coffees_count.dart
+++ b/widget_driver/example/lib/models/consumed_coffees_count.dart
@@ -1,0 +1,5 @@
+class ConsumedCoffeesCount {
+  final int count;
+
+  const ConsumedCoffeesCount(this.count);
+}

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.dart
@@ -12,7 +12,7 @@ class CoffeeCommunityPageDriver extends WidgetDriver {
   StreamSubscription? _subscription;
 
   CoffeeCommunityPageDriver(BuildContext context)
-      : _authService = context.watch<AuthService>(),
+      : _authService = context.read<AuthService>(),
         super(context) {
     _subscription = _authService.isLoggedInStream.listen((_) {
       notifyWidget();
@@ -27,4 +27,7 @@ class CoffeeCommunityPageDriver extends WidgetDriver {
     _subscription?.cancel();
     super.dispose();
   }
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {}
 }

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
@@ -7,8 +7,9 @@ part of 'coffee_community_page_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestCoffeeCommunityPageDriver extends TestDriver implements CoffeeCommunityPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_community_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestCoffeeCommunityPageDriver extends TestDriver implements CoffeeCommunityPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.dart
@@ -32,8 +32,11 @@ class CoffeeDetailPageDriver extends WidgetDriver implements _$DriverProvidedPro
   }
 
   @override
-  void updateDriverProvidedProperties({required int newIndex, required Coffee newCoffee}) {
+  void didUpdateProvidedProperties({required int newIndex, required Coffee newCoffee}) {
     _index = newIndex;
     _coffee = newCoffee;
   }
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {}
 }

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
@@ -7,8 +7,9 @@ part of 'coffee_detail_page_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestCoffeeDetailPageDriver extends TestDriver implements CoffeeDetailPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_detail_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestCoffeeDetailPageDriver extends TestDriver implements CoffeeDetailPageDriver {
   @override
@@ -54,11 +54,11 @@ class $CoffeeDetailPageDriverProvider extends WidgetDriverProvider<CoffeeDetailP
     //    ...
     //
     //    @override
-    //    void updateDriverProvidedProperties(...) {
+    //    void didUpdateProvidedProperties(...) {
     //      // Handle your updates
     //    }
     //  }
-    driver.updateDriverProvidedProperties(
+    driver.didUpdateProvidedProperties(
       newIndex: _index,
       newCoffee: _coffee,
     );
@@ -80,9 +80,9 @@ abstract class _$DriverProvidedProperties {
   ///
   /// Very Important!!
   /// Because this function is running during the build process,
-  /// it is NOT the place to run time cosuming or blocking tasks etc. (like calling Api-Endpoints)
+  /// it is NOT the place to run time consuming or blocking tasks etc. (like calling Api-Endpoints)
   /// This could greatly impact your apps performance.
-  void updateDriverProvidedProperties({
+  void didUpdateProvidedProperties({
     required int newIndex,
     required Coffee newCoffee,
   });

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.dart
@@ -49,4 +49,7 @@ class CoffeeLibraryPageDriver extends WidgetDriver {
     _subscription?.cancel();
     super.dispose();
   }
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {}
 }

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_library_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestCoffeeLibraryPageDriver extends TestDriver implements CoffeeLibraryPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
@@ -7,8 +7,9 @@ part of 'coffee_library_page_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestCoffeeLibraryPageDriver extends TestDriver implements CoffeeLibraryPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.dart
@@ -39,4 +39,7 @@ class NotLoggedInPageDriver extends WidgetDriver {
       },
     );
   }
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {}
 }

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'not_logged_in_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestNotLoggedInPageDriver extends TestDriver implements NotLoggedInPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
@@ -7,8 +7,9 @@ part of 'not_logged_in_page_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestNotLoggedInPageDriver extends TestDriver implements NotLoggedInPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.dart
@@ -10,7 +10,7 @@ part 'register_account_page_driver.g.dart';
 @GenerateTestDriver()
 class RegisterAccountPageDriver extends WidgetDriver {
   final Localization _localization;
-  final CreateUserService _createUserService;
+  CreateUserService _createUserService;
   final Coordinator _coordinator;
 
   String _currentUsername = '';
@@ -20,10 +20,9 @@ class RegisterAccountPageDriver extends WidgetDriver {
   RegisterAccountPageDriver(
     BuildContext context, {
     Localization? localization,
-    CreateUserService? createUserService,
     Coordinator? coordinator,
   })  : _localization = context.read<Localization>(),
-        _createUserService = createUserService ?? context.read<CreateUserService>(),
+        _createUserService = context.watch<CreateUserService>(),
         _coordinator = coordinator ?? Coordinator(),
         super(context);
 
@@ -80,5 +79,10 @@ class RegisterAccountPageDriver extends WidgetDriver {
   void _setRegisterLoading(bool isLoading) {
     _registerIsLoading = isLoading;
     notifyWidget();
+  }
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {
+    _createUserService = context.watch<CreateUserService>();
   }
 }

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
@@ -7,8 +7,9 @@ part of 'register_account_page_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestRegisterAccountPageDriver extends TestDriver implements RegisterAccountPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'register_account_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestRegisterAccountPageDriver extends TestDriver implements RegisterAccountPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:widget_driver/widget_driver.dart';
 
 import 'coffee_counter_widget_driver.dart';
+import 'counter_header_widget.dart';
 
 class CoffeeCounterWidget extends DrivableWidget<CoffeeCounterWidgetDriver> {
   CoffeeCounterWidget({Key? key}) : super(key: key);
@@ -11,8 +13,10 @@ class CoffeeCounterWidget extends DrivableWidget<CoffeeCounterWidgetDriver> {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Text(driver.descriptionText),
-        Text(driver.amountText),
+        Provider.value(
+          value: driver.consumedCoffeeCount,
+          child: CounterHeaderWidget(),
+        ),
         const SizedBox(height: 30),
         ElevatedButton(
           onPressed: driver.consumeCoffeeQuick,

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:widget_driver/widget_driver.dart';
 
 import '../../../localization/localization.dart';
+import '../../../models/consumed_coffees_count.dart';
 import '../../../services/coffee_consumption_service.dart';
 
 part 'coffee_counter_widget_driver.g.dart';
@@ -28,11 +29,8 @@ class CoffeeCounterWidgetDriver extends WidgetDriver {
     });
   }
 
-  @TestDriverDefaultValue('Consumed coffees')
-  String get descriptionText => _localization().consumedCoffees;
-
-  @TestDriverDefaultValue('3')
-  String get amountText => '${_consumptionService.counter}';
+  @TestDriverDefaultValue(ConsumedCoffeesCount(3))
+  ConsumedCoffeesCount get consumedCoffeeCount => ConsumedCoffeesCount(_consumptionService.counter);
 
   @TestDriverDefaultValue('Consume coffee quick')
   String get consumeCoffeeQuickButtonText => _localization().consumeCoffeeQuick;
@@ -79,4 +77,7 @@ class CoffeeCounterWidgetDriver extends WidgetDriver {
   }
 
   Localization _localization() => _locator<Localization>();
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {}
 }

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
@@ -7,15 +7,13 @@ part of 'coffee_counter_widget_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestCoffeeCounterWidgetDriver extends TestDriver implements CoffeeCounterWidgetDriver {
   @override
-  String get descriptionText => 'Consumed coffees';
-
-  @override
-  String get amountText => '3';
+  ConsumedCoffeesCount get consumedCoffeeCount => ConsumedCoffeesCount(3);
 
   @override
   String get consumeCoffeeQuickButtonText => 'Consume coffee quick';

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_counter_widget_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestCoffeeCounterWidgetDriver extends TestDriver implements CoffeeCounterWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/counter_header_widget.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/counter_header_widget.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import 'counter_header_widget_driver.dart';
+
+class CounterHeaderWidget extends DrivableWidget<CounterHeaderWidgetDriver> {
+  CounterHeaderWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(driver.descriptionText),
+        Text(driver.amountText),
+      ],
+    );
+  }
+
+  @override
+  WidgetDriverProvider<CounterHeaderWidgetDriver> get driverProvider => $CounterHeaderWidgetDriverProvider();
+}

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/counter_header_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/counter_header_widget_driver.dart
@@ -1,0 +1,29 @@
+import 'package:provider/provider.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import '../../../localization/localization.dart';
+import '../../../models/consumed_coffees_count.dart';
+
+part 'counter_header_widget_driver.g.dart';
+
+@GenerateTestDriver()
+class CounterHeaderWidgetDriver extends WidgetDriver {
+  late ConsumedCoffeesCount _consumedCoffeesCount;
+  final Locator _locator;
+
+  CounterHeaderWidgetDriver(BuildContext context)
+      : _consumedCoffeesCount = context.watch<ConsumedCoffeesCount>(),
+        _locator = context.read,
+        super(context);
+
+  @TestDriverDefaultValue('Consumed coffees')
+  String get descriptionText => _locator<Localization>().consumedCoffees;
+
+  @TestDriverDefaultValue('3')
+  String get amountText => '${_consumedCoffeesCount.count}';
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {
+    _consumedCoffeesCount = context.watch<ConsumedCoffeesCount>();
+  }
+}

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/counter_header_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/counter_header_widget_driver.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'counter_header_widget_driver.dart';
+
+// **************************************************************************
+// WidgetDriverGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+
+// This file was generated with widget_driver_generator version "0.2.0"
+
+class _$TestCounterHeaderWidgetDriver extends TestDriver implements CounterHeaderWidgetDriver {}
+
+class $CounterHeaderWidgetDriverProvider extends WidgetDriverProvider<CounterHeaderWidgetDriver> {
+  @override
+  CounterHeaderWidgetDriver buildDriver(BuildContext context) {
+    return CounterHeaderWidgetDriver(context);
+  }
+
+  @override
+  CounterHeaderWidgetDriver buildTestDriver() {
+    return _$TestCounterHeaderWidgetDriver();
+  }
+}

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/counter_header_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/counter_header_widget_driver.g.dart
@@ -7,10 +7,17 @@ part of 'counter_header_widget_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
-class _$TestCounterHeaderWidgetDriver extends TestDriver implements CounterHeaderWidgetDriver {}
+class _$TestCounterHeaderWidgetDriver extends TestDriver implements CounterHeaderWidgetDriver {
+  @override
+  String get descriptionText => 'Consumed coffees';
+
+  @override
+  String get amountText => '3';
+}
 
 class $CounterHeaderWidgetDriverProvider extends WidgetDriverProvider<CounterHeaderWidgetDriver> {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.dart
@@ -32,4 +32,7 @@ class RandomCoffeeImageWidgetDriver extends WidgetDriver {
   void updateRandomImage() {
     notifyWidget();
   }
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {}
 }

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
@@ -7,8 +7,9 @@ part of 'random_coffee_image_widget_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestRandomCoffeeImageWidgetDriver extends TestDriver implements RandomCoffeeImageWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
@@ -8,7 +8,7 @@ part of 'random_coffee_image_widget_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestRandomCoffeeImageWidgetDriver extends TestDriver implements RandomCoffeeImageWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
@@ -28,4 +28,7 @@ class HomePageDriver extends WidgetDriver {
 
   @TestDriverDefaultValue([AppTabType.consumption, AppTabType.community])
   List<AppTabType> get appTabs => _appTabs.tabs;
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {}
 }

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'home_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestHomePageDriver extends TestDriver implements HomePageDriver {
   @override

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
@@ -7,8 +7,9 @@ part of 'home_page_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestHomePageDriver extends TestDriver implements HomePageDriver {
   @override

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.dart
@@ -15,7 +15,7 @@ class LogInOutButtonDriver extends WidgetDriver {
   StreamSubscription? _subscription;
 
   LogInOutButtonDriver(BuildContext context)
-      : _authService = context.watch<AuthService>(),
+      : _authService = context.read<AuthService>(),
         _locator = context.read,
         super(context) {
     _subscription = _authService.isLoggedInStream.listen((_) {
@@ -44,4 +44,7 @@ class LogInOutButtonDriver extends WidgetDriver {
   }
 
   Localization _localization() => _locator<Localization>();
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {}
 }

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
@@ -8,7 +8,7 @@ part of 'log_in_out_button_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestLogInOutButtonDriver extends TestDriver implements LogInOutButtonDriver {
   @override

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
@@ -7,8 +7,9 @@ part of 'log_in_out_button_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestLogInOutButtonDriver extends TestDriver implements LogInOutButtonDriver {
   @override

--- a/widget_driver/example/lib/widgets/my_app_driver.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.dart
@@ -15,4 +15,7 @@ class MyAppDriver extends WidgetDriver {
 
   @TestDriverDefaultValue('Coffee Demo App')
   String get appTitle => _locator<Localization>().appTitle;
+
+  @override
+  void didUpdateBuildContextDependencies(BuildContext context) {}
 }

--- a/widget_driver/example/lib/widgets/my_app_driver.g.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.g.dart
@@ -7,8 +7,9 @@ part of 'my_app_driver.dart';
 // **************************************************************************
 
 // coverage:ignore-file
+// ignore_for_file: prefer_const_constructors
 
-// This file was generated with widget_driver_generator version "0.2.0"
+// This file was generated with widget_driver_generator version "0.2.1"
 
 class _$TestMyAppDriver extends TestDriver implements MyAppDriver {
   @override

--- a/widget_driver/example/lib/widgets/my_app_driver.g.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.g.dart
@@ -8,7 +8,7 @@ part of 'my_app_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.1.0"
+// This file was generated with widget_driver_generator version "0.2.0"
 
 class _$TestMyAppDriver extends TestDriver implements MyAppDriver {
   @override

--- a/widget_driver/example/pubspec.yaml
+++ b/widget_driver/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  widget_driver: ^0.0.8
+  widget_driver: ^0.1.0
   meta: ^1.7.0
   get_it: ^7.2.0
   provider: ^6.0.4

--- a/widget_driver_generator/CHANGELOG.md
+++ b/widget_driver_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.1
+
+* Adds dart analyzer ignore to generated TestDrivers for ignoring adding const to properties.
+
 ## 0.2.0
 
 * Changes the name of the generated method for driver provided properties. It used to be `updateDriverProvidedProperties`, now it is called `didUpdateProvidedProperties` to fit better with the name of the method which is called when a build context dependency triggers the driver to update.

--- a/widget_driver_generator/lib/src/widget_driver_generator.dart
+++ b/widget_driver_generator/lib/src/widget_driver_generator.dart
@@ -27,11 +27,12 @@ class WidgetDriverGenerator extends GeneratorForAnnotation<GenerateTestDriver> {
     final codeWriter = CodeWriter();
     final driverClassName = visitor.className;
 
-    //#####################################################
-    // Start - Package version generation and code coverage
-    //#####################################################
+    //#################################################################
+    // Start - Package version generation and coverage/analyzer ignore
+    //#################################################################
 
-    codeWriter.writeCode('// coverage:ignore-file\n');
+    codeWriter.writeCode('// coverage:ignore-file');
+    codeWriter.writeCode('// ignore_for_file: prefer_const_constructors\n');
 
     final packageVersionString = await _packageInfoProvider.getPackageVersionString();
     codeWriter.writeCode('// This file was generated with widget_driver_generator version $packageVersionString\n');

--- a/widget_driver_generator/pubspec.yaml
+++ b/widget_driver_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_generator
 description: This package provides generators for WidgetDriver to automate the creation of your TestDrivers and WidgetDriverProviders
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_generator
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widget_driver: ^0.0.6
+  widget_driver: ^0.1.0
   mocktail: ^0.1.4
   meta: ^1.7.0
   test: ^1.16.0


### PR DESCRIPTION
# Wait to merge this. Might become irrelevant after the BuildContext logic change

## Description
Updates example app to use latest widget_driver 0.1.0 api.

Also adds an example to example app where a driver uses a dependency from a build context which changes over time.

## Type of Change

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
