### PR TITLE
Changes how buildContext is provided to the WidgetDriver. Updates widget_driver and widget_driver_generator

### DIFF
--- a/widget_driver/CHANGELOG.md
+++ b/widget_driver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.2.0
+
+* Refactors WidgetDriver to no longer get the BuildContext passed into via the constructor.  
+Instead the driver now has an optional method called `didUpdateBuildContext` which is called once directly after the constructor. And then this method is called again if any inherited build context dependency did change.
+
 ## 0.1.0
 
 * Adds a new method which your drivers are forced to implement. This new method is `didUpdateBuildContextDependencies` and it is called by the framework if your driver has a dependency to an inherited widget from the build context and that dependency updates.

--- a/widget_driver/doc/drivers_without_generation.md
+++ b/widget_driver/doc/drivers_without_generation.md
@@ -42,8 +42,8 @@ This is also easy to define. You just need to extend `WidgetDriverProvider` and 
 class MyCoolWidgetDriverProvider
     extends WidgetDriverProvider<MyCoolWidgetDriver> {
   @override
-  MyCoolWidgetDriver buildDriver(BuildContext context) {
-    return MyCoolWidgetDriver(context);
+  MyCoolWidgetDriver buildDriver() {
+    return MyCoolWidgetDriver();
   }
 
   @override
@@ -53,7 +53,7 @@ class MyCoolWidgetDriverProvider
 }
 ```
 
-The `WidgetDriverProvider` has two methods which you need to override. The `buildDriver(BuildContext context)` and `buildTestDriver()`. In the `buildDriver(...)` you create an instance of your real `driver` and return it.
+The `WidgetDriverProvider` has two methods which you need to override. The `buildDriver()` and `buildTestDriver()`. In the `buildDriver()` you create an instance of your real `driver` and return it.
 
 And in the `buildTestDriver()` you create and instance of your `testDriver` and return it. Makes sense right 😁
 

--- a/widget_driver/doc/testing.md
+++ b/widget_driver/doc/testing.md
@@ -70,7 +70,7 @@ Well they are easier to test than widgets, since they are not ui components.
 So basically they are just unit tests. You do not need to find some buttons and do some fake tapping.
 You just have to test that they provide the correct property values depending on their internal dependencies.
 
-**But**, yes there is a but, it becomes a bit tricky to test `WidgetDrivers` since they need the BuildContext in their constructor.
+**But**, yes there is a but, it becomes a bit tricky to test `WidgetDrivers` since they might need the BuildContext. `WidgetDriver` has an optional method which you can override called `didUpdateBuildContext(...)` which should provide a valid BuildContext which your driver can use to resolve a dependency.
 
 It is not super straightforward how to get an instance of the build context.
 But luckily we have created some helper code for you to make this easy.
@@ -88,7 +88,7 @@ void main() {
 ### Create a driver
 
 To create your driver you will need a helper function.  
-This is because the `Driver` needs a build context as a parameter to its constructor.
+This is because the `Driver` might need a BuildContext as a parameter to its `didUpdateBuildContext`.
 To help you with this we have created a helper function on the `WidgetTester`.
 
 This is how you create your `Driver`:
@@ -96,7 +96,7 @@ This is how you create your `Driver`:
 ```dart
 testWidgets('Some driver test', (WidgetTester tester) async {
     final driverTester = await tester.getDriverTester<MyWidgetDriver>(
-          driverBuilder: (context) => MyWidgetDriver(context, theService: mockTheService),
+          driverBuilder: () => MyWidgetDriver(theService: mockTheService),
           parentWidgetBuilder: (driverWidget) {
             return MultiProvider(
               providers: [

--- a/widget_driver/lib/src/drivable_widget.dart
+++ b/widget_driver/lib/src/drivable_widget.dart
@@ -51,7 +51,7 @@ class _DriverWidgetState<Driver extends WidgetDriver> extends State<DrivableWidg
   /// Describes the part of the user interface represented by this widget.
   @override
   Widget build(BuildContext context) {
-    final driver = _getDriverAndSetupUpIfNeeded(context);
+    final driver = _getDriverAndSetupUpIfNeeded();
     widget._widgetDriverContainer.instance = driver;
     return widget.build(context);
   }
@@ -68,24 +68,23 @@ class _DriverWidgetState<Driver extends WidgetDriver> extends State<DrivableWidg
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (_driverExists) {
-      // If didChangeDependencies get's called this means your driver depends on a value from the BuildContext,
-      // which the flutter framework marked as "has changed".
-      // Thus we need to tell the driver about this so that it can update any logic depending on that dependency.
-      _driver!.didUpdateBuildContextDependencies(context);
+      _driver!.didUpdateBuildContext(context);
     }
   }
 
-  Driver _getDriverAndSetupUpIfNeeded(BuildContext context) {
+  Driver _getDriverAndSetupUpIfNeeded() {
     if (_driverExists) {
       return _driver!;
     }
 
     Driver driver;
     if (_isRunningInTestEnvironment()) {
-      driver = _getTestDriver(context);
+      driver = _getTestDriver();
     } else {
-      driver = _getRealDriver(context);
+      driver = _getRealDriver();
     }
+
+    driver.didUpdateBuildContext(context);
 
     driver.addListener(() {
       if (mounted) {
@@ -101,11 +100,11 @@ class _DriverWidgetState<Driver extends WidgetDriver> extends State<DrivableWidg
     return widget._environmentInfo.isRunningInTestEnvironment();
   }
 
-  Driver _getRealDriver(BuildContext context) {
-    return widget.driverProvider.buildDriver(context);
+  Driver _getRealDriver() {
+    return widget.driverProvider.buildDriver();
   }
 
-  Driver _getTestDriver(BuildContext context) {
+  Driver _getTestDriver() {
     // Check if we have an injected MockDriver for the current type.
     // If it exists and it was not already assigned as current driver,
     // then update the current driver.

--- a/widget_driver/lib/src/widget_driver.dart
+++ b/widget_driver/lib/src/widget_driver.dart
@@ -64,8 +64,6 @@ import 'package:meta/meta.dart';
 abstract class WidgetDriver {
   ValueNotifier<bool>? _widgetNotifier = ValueNotifier<bool>(true);
 
-  WidgetDriver(BuildContext context);
-
   @nonVirtual
   void notifyWidget() {
     if (_widgetNotifier != null) {
@@ -86,19 +84,23 @@ abstract class WidgetDriver {
     }
   }
 
-  /// If the [WidgetDriver] constructor referenced an
-  /// [InheritedWidget] from the [BuildContext] that later changed, then
-  /// the framework will call this method to notify this driver about the change.
+  /// If the [WidgetDriver] needs a dependency from
+  /// the [BuildContext] then you can override this method.
   ///
-  /// Use this method to grab the latest value for your dependency from the [BuildContext].
-  /// Since the value which you got in the [WidgetDriver] constructor might be outdated/changed.
+  /// This method is called directly after the driver is created,
+  /// and before the build method is called on the corresponding [DrivableWidget].
   ///
-  /// The framework always calls [build] after a dependency changes.
+  /// You can use this to grab all the needed dependencies from the context.
+  ///
+  /// If you reference any [InheritedWidget] from the [BuildContext] that later changes, then
+  /// the framework will call this method again to notify this driver about the change.
+  ///
+  /// The framework always calls [build] on your [DrivableWidget] after a dependency changes.
   /// So there is no need to call `notifyWidget` in this method since the widget's build method is called anyways.
   ///
   /// NOTE: If your driver is not referencing an [InheritedWidget]
-  /// then you can ignore this method since it will anyways never be called.
-  void didUpdateBuildContextDependencies(BuildContext context);
+  /// then this method is only called once directly after the driver creation.
+  void didUpdateBuildContext(BuildContext context) {}
 }
 
 /// A base class for the test version of the WidgetDrivers.
@@ -124,4 +126,6 @@ class TestDriver {
   void notifyWidget() {}
 
   void dispose() {}
+
+  void didUpdateBuildContext(BuildContext context) {}
 }

--- a/widget_driver/lib/src/widget_driver_provider.dart
+++ b/widget_driver/lib/src/widget_driver_provider.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-
 import 'widget_driver.dart';
 
 /// This is a factory which knows how to create `Drivers`.
@@ -9,7 +7,7 @@ import 'widget_driver.dart';
 /// And when running the real app then the real Driver gets created.
 abstract class WidgetDriverProvider<Driver extends WidgetDriver> {
   /// Creates and returns the `Driver` with the real business logic.
-  Driver buildDriver(BuildContext context);
+  Driver buildDriver();
 
   /// Creates and returns the `Driver` with the hard coded test values.
   Driver buildTestDriver();

--- a/widget_driver/pubspec.yaml
+++ b/widget_driver/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver
 description: A Flutter presentation layer framework, which will clean up your widget code and make your widgets testable without a need for thousands of mock objects. Let's go driving!
-version: 0.1.0
+version: 0.2.0
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 

--- a/widget_driver/test/drivable_widget_test.dart
+++ b/widget_driver/test/drivable_widget_test.dart
@@ -109,12 +109,13 @@ void main() {
       });
     });
 
-    group('BuildContext dependencies:', () {
+    group('BuildContext updates:', () {
       setUp(() {
         when(() => _mockRuntimeEnvironmentInfo.isRunningInTestEnvironment()).thenReturn(false);
       });
 
-      testWidgets('Does not call didUpdateBuildContextDependencies, if there are no buildContext dependencies',
+      testWidgets(
+          'Only calls didUpdateBuildContext 1 time (after construction), if there are no registered buildContext dependencies',
           (tester) async {
         late TestContainerDriver driver;
         final testContainerDrivableWidget = WrappedTestContainer(
@@ -126,15 +127,16 @@ void main() {
         await tester.pumpWidget(testContainerDrivableWidget);
         final firstDriver = driver;
 
-        expect(driver.numberOfCallsToUpdateBuildContextDependencies, 0);
+        expect(driver.numberOfCallsToUpdateBuildContext, 1);
 
         await _tapButtonToIncreaseSomeData(tester);
 
-        expect(driver.numberOfCallsToUpdateBuildContextDependencies, 0);
+        expect(driver.numberOfCallsToUpdateBuildContext, 1);
         expect(identical(driver, firstDriver), isTrue);
       });
 
-      testWidgets('Does not call didUpdateBuildContextDependencies, if we only read from buildContext', (tester) async {
+      testWidgets('Only calls didUpdateBuildContext 1 time (after construction), if we only read from buildContext',
+          (tester) async {
         late TestContainerDriver driver;
         final testContainerDrivableWidget = WrappedTestContainer(
           environmentInfo: _mockRuntimeEnvironmentInfo,
@@ -145,19 +147,20 @@ void main() {
         await tester.pumpWidget(testContainerDrivableWidget);
         final firstDriver = driver;
 
-        expect(driver.numberOfCallsToUpdateBuildContextDependencies, 0);
+        expect(driver.numberOfCallsToUpdateBuildContext, 1);
         expect(driver.readDataValue, 0);
 
         await _tapButtonToIncreaseSomeData(tester);
 
-        expect(driver.numberOfCallsToUpdateBuildContextDependencies, 0);
+        expect(driver.numberOfCallsToUpdateBuildContext, 1);
         // Should still be zero since we are not watching anything from build context.
         // So the driver does not get updated.
         expect(driver.readDataValue, 0);
         expect(identical(driver, firstDriver), isTrue);
       });
 
-      testWidgets('Does not call didUpdateBuildContextDependencies, if we watch buildContext but it never changes',
+      testWidgets(
+          'Only calls didUpdateBuildContext 1 time (after construction), if we watch buildContext but it never changes',
           (tester) async {
         late TestContainerDriver driver;
         final testContainerDrivableWidget = WrappedTestContainer(
@@ -169,18 +172,17 @@ void main() {
         await tester.pumpWidget(testContainerDrivableWidget);
         final firstDriver = driver;
 
-        expect(driver.numberOfCallsToUpdateBuildContextDependencies, 0);
+        expect(driver.numberOfCallsToUpdateBuildContext, 1);
         expect(driver.watchDataValue, 0);
 
         await _tapButtonWhichDoesNothingJustCallsSetState(tester);
 
-        expect(driver.numberOfCallsToUpdateBuildContextDependencies, 0);
+        expect(driver.numberOfCallsToUpdateBuildContext, 1);
         expect(driver.watchDataValue, 0);
         expect(identical(driver, firstDriver), isTrue);
       });
 
-      testWidgets('Does call didUpdateBuildContextDependencies, if we watch buildContext and it changes',
-          (tester) async {
+      testWidgets('Calls didUpdateBuildContext more times, if we watch buildContext and it changes', (tester) async {
         late TestContainerDriver driver;
         final testContainerDrivableWidget = WrappedTestContainer(
           environmentInfo: _mockRuntimeEnvironmentInfo,
@@ -191,18 +193,18 @@ void main() {
         await tester.pumpWidget(testContainerDrivableWidget);
         final firstDriver = driver;
 
-        expect(driver.numberOfCallsToUpdateBuildContextDependencies, 0);
+        expect(driver.numberOfCallsToUpdateBuildContext, 1);
         expect(driver.watchDataValue, 0);
 
         await _tapButtonToIncreaseSomeData(tester);
 
-        expect(driver.numberOfCallsToUpdateBuildContextDependencies, 1);
+        expect(driver.numberOfCallsToUpdateBuildContext, 2);
         expect(driver.watchDataValue, 1);
         expect(identical(driver, firstDriver), isTrue);
 
         await _tapButtonToIncreaseSomeData(tester);
 
-        expect(driver.numberOfCallsToUpdateBuildContextDependencies, 2);
+        expect(driver.numberOfCallsToUpdateBuildContext, 3);
         expect(driver.watchDataValue, 2);
         expect(identical(driver, firstDriver), isTrue);
       });

--- a/widget_driver/test/mock_driver_provider_test.dart
+++ b/widget_driver/test/mock_driver_provider_test.dart
@@ -14,6 +14,7 @@ void main() {
     setUp(() {
       _mockTestContainerDriver = _MockTestContainerDriver();
       when(() => _mockTestContainerDriver.didCallTestMethod).thenReturn(false);
+      when(() => _mockTestContainerDriver.someData).thenReturn(1);
     });
 
     testWidgets('Verify that mocked driver overrides real driver property', (WidgetTester tester) async {

--- a/widget_driver/test/test_helpers/test_container_drivable_widget.dart
+++ b/widget_driver/test/test_helpers/test_container_drivable_widget.dart
@@ -14,19 +14,22 @@ class TestContainerDriver extends WidgetDriver {
   final bool _readFromContext;
   final bool _watchFromContext;
 
-  TestContainerDriver(
-    BuildContext context, {
+  TestContainerDriver({
     int? newSomeData,
     required bool readFromContext,
     required bool watchFromContext,
   })  : _readFromContext = readFromContext,
         _watchFromContext = watchFromContext,
-        someData = newSomeData ?? -1,
-        super(context) {
-    if (readFromContext) {
+        someData = newSomeData ?? -1;
+
+  int numberOfCallsToUpdateBuildContext = 0;
+  @override
+  void didUpdateBuildContext(BuildContext context) {
+    numberOfCallsToUpdateBuildContext += 1;
+    if (_readFromContext) {
       readDataValue = context.read<ReadData>().value;
     }
-    if (watchFromContext) {
+    if (_watchFromContext) {
       watchDataValue = context.watch<WatchData>().value;
     }
   }
@@ -44,20 +47,6 @@ class TestContainerDriver extends WidgetDriver {
   void didUpdateProvidedProperties({required int newSomeData}) {
     someData = newSomeData;
     numberOfCallsToUpdateDriverProvidedProperties += 1;
-  }
-
-  int numberOfCallsToUpdateBuildContextDependencies = 0;
-
-  @override
-  void didUpdateBuildContextDependencies(BuildContext context) {
-    numberOfCallsToUpdateBuildContextDependencies += 1;
-
-    if (_readFromContext) {
-      readDataValue = context.read<ReadData>().value;
-    }
-    if (_watchFromContext) {
-      watchDataValue = context.watch<WatchData>().value;
-    }
   }
 }
 
@@ -94,9 +83,8 @@ class TestContainerDriverProvider extends WidgetDriverProvider<TestContainerDriv
         _watchFromContext = watchFromContext ?? false;
 
   @override
-  TestContainerDriver buildDriver(BuildContext context) {
+  TestContainerDriver buildDriver() {
     return TestContainerDriver(
-      context,
       newSomeData: _someData,
       readFromContext: _readFromContext,
       watchFromContext: _watchFromContext,

--- a/widget_driver/test/widget_driver_test.dart
+++ b/widget_driver/test/widget_driver_test.dart
@@ -12,7 +12,7 @@ void main() {
         int numberOfDriverListenersEmits = 0;
 
         final driverTester = await tester.getDriverTester(
-          driverBuilder: (context) => _ConcreteWidgetDriver(context),
+          driverBuilder: () => _ConcreteWidgetDriver(),
         );
         final driver = driverTester.driver;
         driver.addListener(() {
@@ -28,7 +28,7 @@ void main() {
         int numberOfDriverListenersEmits = 0;
 
         final driverTester = await tester.getDriverTester(
-          driverBuilder: (context) => _ConcreteWidgetDriver(context),
+          driverBuilder: () => _ConcreteWidgetDriver(),
         );
         final driver = driverTester.driver;
         driver.addListener(() {
@@ -47,7 +47,7 @@ void main() {
         int numberOfDriverListenersEmits = 0;
 
         final driverTester = await tester.getDriverTester(
-          driverBuilder: (context) => _ConcreteWidgetDriver(context),
+          driverBuilder: () => _ConcreteWidgetDriver(),
         );
         final driver = driverTester.driver;
         driver.addListener(() {
@@ -70,7 +70,7 @@ void main() {
         bool disposeWasCalled = false;
 
         final driverTester = await tester.getDriverTester(
-          driverBuilder: (context) => _ConcreteWidgetDriver(context),
+          driverBuilder: () => _ConcreteWidgetDriver(),
         );
         final driver = driverTester.driver;
         driver.disposedCallback = () {
@@ -88,7 +88,7 @@ void main() {
         bool disposeWasCalled = false;
 
         final driverTester = await tester.getDriverTester(
-          driverBuilder: (context) => _ConcreteWidgetDriver(context),
+          driverBuilder: () => _ConcreteWidgetDriver(),
         );
         final driver = driverTester.driver;
         driver.disposedCallback = () {
@@ -118,7 +118,7 @@ void main() {
       bool disposeWasCalled = false;
 
       final driverTester = await tester.getDriverTester(
-        driverBuilder: (context) => _ConcreteTestDriver(),
+        driverBuilder: () => _ConcreteTestDriver(),
       );
       final driver = driverTester.driver;
       driver.disposedCallback = () {
@@ -135,7 +135,7 @@ void main() {
     testWidgets('Calling function with no placeholder implementation throws', (WidgetTester tester) async {
       bool didThrowNoSuchMethodError = false;
       final driverTester = await tester.getDriverTester(
-        driverBuilder: (context) => _ConcreteTestDriver(),
+        driverBuilder: () => _ConcreteTestDriver(),
       );
       final driver = driverTester.driver;
       try {
@@ -155,8 +155,6 @@ void main() {
 class _ConcreteWidgetDriver extends WidgetDriver {
   VoidCallback? disposedCallback;
 
-  _ConcreteWidgetDriver(BuildContext context) : super(context);
-
   void someEmptyFunction() {}
 
   @override
@@ -168,7 +166,7 @@ class _ConcreteWidgetDriver extends WidgetDriver {
   }
 
   @override
-  void didUpdateBuildContextDependencies(BuildContext context) {}
+  void didUpdateBuildContext(BuildContext context) {}
 }
 
 class _ConcreteTestDriver extends TestDriver implements _ConcreteWidgetDriver {

--- a/widget_driver_generator/CHANGELOG.md
+++ b/widget_driver_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.0
+
+* Updates generator to be compatible with latest api changes in version 0.2.0 of widget_driver.
+
 ## 0.2.0
 
 * Changes the name of the generated method for driver provided properties. It used to be `updateDriverProvidedProperties`, now it is called `didUpdateProvidedProperties` to fit better with the name of the method which is called when a build context dependency triggers the driver to update.

--- a/widget_driver_generator/lib/src/code_providers/driver_provider_code_provider.dart
+++ b/widget_driver_generator/lib/src/code_providers/driver_provider_code_provider.dart
@@ -102,7 +102,7 @@ class DriverProviderCodeProvider {
         _providedNamedFields.isNotEmpty ? '${_providedNamedFields.map((e) => '${e.name}: _${e.name}').join(',')},' : '';
     final positionalVariables =
         _providedPositionalFields.isNotEmpty ? '${_providedPositionalFields.map((e) => '_${e.name}').join(',')},' : '';
-    return ', $positionalVariables $namedVariables';
+    return '$positionalVariables $namedVariables';
   }
 
   String _updateParameters() {
@@ -113,8 +113,8 @@ class DriverProviderCodeProvider {
   String _classWithoutFields() => '''
 class $_providerClassName extends WidgetDriverProvider<$_driverClassName> {
   @override
-  $_driverClassName buildDriver(BuildContext context) {
-    return $_driverClassName(context);
+  $_driverClassName buildDriver() {
+    return $_driverClassName();
   }
 
   @override
@@ -134,8 +134,8 @@ class $_providerClassName extends WidgetDriverProvider<$_driverClassName> {
   }) : ${_constructorInitializer()};
 
   @override
-  $_driverClassName buildDriver(BuildContext context) {
-    return $_driverClassName(context ${_parameters()});
+  $_driverClassName buildDriver() {
+    return $_driverClassName(${_parameters()});
   }
 
   @override

--- a/widget_driver_generator/pubspec.yaml
+++ b/widget_driver_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_generator
 description: This package provides generators for WidgetDriver to automate the creation of your TestDrivers and WidgetDriverProviders
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_generator
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 

--- a/widget_driver_generator/test/code_providers/driver_provider_code_provider_test.dart
+++ b/widget_driver_generator/test/code_providers/driver_provider_code_provider_test.dart
@@ -13,8 +13,8 @@ void main() {
       const expectedCode = '''
 class \$ExampleDriverProvider extends WidgetDriverProvider<ExampleDriver> {
   @override
-  ExampleDriver buildDriver(BuildContext context) {
-    return ExampleDriver(context);
+  ExampleDriver buildDriver() {
+    return ExampleDriver();
   }
 
   @override
@@ -56,8 +56,8 @@ required String example2,
   }) : _example = example,_example2 = example2;
 
   @override
-  ExampleDriver buildDriver(BuildContext context) {
-    return ExampleDriver(context , _example, example2: _example2,);
+  ExampleDriver buildDriver() {
+    return ExampleDriver(_example, example2: _example2,);
   }
 
   @override


### PR DESCRIPTION
## Description

This is a breaking API change!

To simplify usage of driver and how they can get dependencies from the BuildContext we changed how the context is provided to the drivers.

Before the BuildContext was passed into the Driver in the drivers constructor.
And then you also had a second method where the BuildContext was provided which was called if an inherited widget dependency changed.

This makes it a bit more complicated to use. You had to know when to implement that second method.
And you might need to do the dependency-setup-work twice.


### Solution

We changed this now and moved the BuildContext out of the driver constructor.
Now there is only one method which is optional to implement.

It is called `didUpdateBuildContext(...)`
It is called by the framework directly after the driver constructor is called.

Now you can use this method to grab any dependency you need from the BuildContext.
And if you grab an inherited widget and that dependency changes, then this very same `didUpdateBuildContext` method is called again.

It just gets simpler for users of WidgetDriver to understand and use.

## Type of Change

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [x] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [x] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [x] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
