### PR TITLE
Adds UpdatableDependency test helper widget to widget_driver_test

### DIFF
--- a/widget_driver/example/lib/resolver/resolver.dart
+++ b/widget_driver/example/lib/resolver/resolver.dart
@@ -1,0 +1,17 @@
+import 'package:provider/provider.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+class Resolver extends DependencyResolver {
+  Resolver(BuildContext context) : super(context);
+
+  @override
+  void registerTestDefaultFallbackValues() {}
+
+  @override
+  T? tryToGetDependencyFromBuildContext<T>(BuildContext context) {
+    try {
+      return context.read<T>();
+    } catch (_) {}
+    return null;
+  }
+}

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_dependency_injector.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_dependency_injector.dart
@@ -12,16 +12,31 @@ class NotLoggedInDependencyInjector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Provider(
-      create: (_) => _DependencyProvider().get(() => CreateUserService(locator: context.read)),
+      create: (_) => _WidgetResolver(context).get(() => CreateUserService(locator: context.read)),
       child: child,
     );
   }
 }
 
-class _DependencyProvider extends DependencyProvider {
+/// Here we use the `DependencyResolver` do help us provide a TestDefault value
+/// which can be used when/if other widget adds this widget as a child,
+/// and we don't want to force other widget tests to need to inject our dependency.
+///
+/// If we would not have wrapped the `CreateUserService(locator: context.read)` inside this
+/// `Resolver`, then any parent widget under test, would need to provide the mock for this child.
+/// But now since we use the `Resolver` here, all ancestor widgets, during testing,
+/// can just ignore all dependencies which their children require. --> Leads to Widget Testing in isolation :-D
+class _WidgetResolver extends DependencyResolver {
+  _WidgetResolver(BuildContext context) : super(context);
+
   @override
   void registerTestDefaultFallbackValues() {
     registerTestDefaultBuilder<CreateUserService>(() => TestDefaultCreateUserService());
+  }
+
+  @override
+  T? tryToGetDependencyFromBuildContext<T>(BuildContext context) {
+    return null;
   }
 }
 

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
@@ -2,6 +2,7 @@ import 'package:provider/provider.dart';
 import 'package:widget_driver/widget_driver.dart';
 
 import '../../localization/localization.dart';
+import '../../resolver/resolver.dart';
 import 'tabs/home_page_tabs.dart';
 
 part 'home_page_driver.g.dart';
@@ -15,7 +16,7 @@ class HomePageDriver extends WidgetDriver {
 
   @override
   void didUpdateBuildContext(BuildContext context) {
-    _localization = context.read<Localization>();
+    _localization = Resolver(context).get(() => context.read<Localization>());
   }
 
   @TestDriverDefaultValue('Coffee Demo App')

--- a/widget_driver/example/lib/widgets/my_app_driver.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.dart
@@ -2,6 +2,7 @@ import 'package:provider/provider.dart';
 import 'package:widget_driver/widget_driver.dart';
 
 import '../localization/localization.dart';
+import '../resolver/resolver.dart';
 
 part 'my_app_driver.g.dart';
 
@@ -11,7 +12,7 @@ class MyAppDriver extends WidgetDriver {
 
   @override
   void didUpdateBuildContext(BuildContext context) {
-    _localization = context.read<Localization>();
+    _localization = Resolver(context).get(() => context.read<Localization>());
   }
 
   @TestDriverDefaultValue('Coffee Demo App')

--- a/widget_driver/example/pubspec.yaml
+++ b/widget_driver/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  widget_driver: ^0.2.0
+  widget_driver: ^0.3.0
   meta: ^1.7.0
   get_it: ^7.2.0
   provider: ^6.0.4

--- a/widget_driver/example/test/driver_tests/coffee_consumption/coffee_counter/coffee_counter_header_section_driver_test.dart
+++ b/widget_driver/example/test/driver_tests/coffee_consumption/coffee_counter/coffee_counter_header_section_driver_test.dart
@@ -1,0 +1,72 @@
+import 'package:example/localization/localization.dart';
+import 'package:example/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+import 'package:widget_driver_test/widget_driver_test.dart';
+
+class MockLocalization extends Mock implements Localization {}
+
+void main() {
+  late MockLocalization mockLocalization;
+  ValueNotifier<int> fakeCoffeeCountNotifier = ValueNotifier<int>(0);
+
+  setUp(() {
+    mockLocalization = MockLocalization();
+  });
+
+  Future<DriverTester<CoffeeCounterHeaderSectionDriver>> _getDriver(WidgetTester tester) async {
+    return tester.getDriverTester(
+      driverBuilder: () => CoffeeCounterHeaderSectionDriver(),
+      parentWidgetBuilder: (driverWidget) {
+        return UpdatableDependency<int>(
+          valueNotifier: fakeCoffeeCountNotifier,
+          builder: (coffeeCount) {
+            return MultiProvider(
+              providers: [
+                Provider<Localization>.value(value: mockLocalization),
+                Provider<int>.value(value: coffeeCount),
+              ],
+              child: driverWidget,
+            );
+          },
+        );
+      },
+    );
+  }
+
+  group('CoffeeCounterHeaderSectionDriver:', () {
+    group('Properties:', () {
+      testWidgets('Has correct value for descriptionText', (tester) async {
+        const expectedText = 'Some text about consumed coffees';
+        when(() => mockLocalization.consumedCoffees).thenReturn(expectedText);
+
+        final driverTester = await _getDriver(tester);
+        expect(driverTester.driver.descriptionText, expectedText);
+      });
+
+      testWidgets('Has correct value for amountText', (tester) async {
+        fakeCoffeeCountNotifier.value = 123;
+
+        final driverTester = await _getDriver(tester);
+        expect(driverTester.driver.amountText, '123');
+      });
+    });
+
+    group('Did update BuildContext:', () {
+      testWidgets('amount text updates when count coming from context updates', (tester) async {
+        // The initial value used when driver is created
+        fakeCoffeeCountNotifier.value = 123;
+
+        final driverTester = await _getDriver(tester);
+        expect(driverTester.driver.amountText, '123');
+
+        // Set a new value to the coffee count and trigger widget tester to render the update.
+        fakeCoffeeCountNotifier.value = 124;
+        await tester.pumpAndSettle();
+        expect(driverTester.driver.amountText, '124');
+      });
+    });
+  });
+}

--- a/widget_driver_test/CHANGELOG.md
+++ b/widget_driver_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+* Adds `UpdatableDependency` to help test the `didUpdateBuildContext` method of drivers.
+
 ## 0.1.0
 
 * Changes to use latest api from widget_driver package. The build context is no longer passed into the constructor of the driver.

--- a/widget_driver_test/README.md
+++ b/widget_driver_test/README.md
@@ -67,14 +67,16 @@ void main() {
 ### Create a driver
 
 To create your driver you will need a helper function.  
-This is because the `Driver` needs a build context as a parameter to its constructor. To help you with this we have created a helper function on the `WidgetTester`.
+This is because the `Driver` needs to be constructed in the correct way by the widget_driver framework. If you would just create an instance of the driver yourself then some parts initialization phase and the lifecycle management of the driver will not work.
+
+To help you with this we have created a helper function on the `WidgetTester`.
 
 This is how you create your `Driver`:
 
 ```dart
 testWidgets('Some driver test', (WidgetTester tester) async {
     final driverTester = await tester.getDriverTester<MyWidgetDriver>(
-          driverBuilder: (context) => MyWidgetDriver(context, theService: mockTheService),
+          driverBuilder: () => MyWidgetDriver(theService: mockTheService),
           parentWidgetBuilder: (driverWidget) {
             return MultiProvider(
               providers: [

--- a/widget_driver_test/lib/src/updatable_dependency.dart
+++ b/widget_driver_test/lib/src/updatable_dependency.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+/// Use this class to simplify testing your Drivers which have dependencies coming
+/// from the [BuildContext] and which could update and trigger that the
+/// `didUpdateBuildContext` method of your driver is called.
+///
+/// E.g. image you have a simple driver like this:
+///
+/// ```dart
+/// class CounterDriver extends WidgetDriver {
+///   late int _counter;
+///
+///   @override
+///   void didUpdateBuildContext(BuildContext context) {
+///     _counter = context.watch<int>();
+///   }
+///
+///   @TestDriverDefaultValue('3')
+///   String get counterText => '$_counter';
+/// }
+/// ```
+///
+/// This driver watches the int value coming from the context.
+/// If that value would change, then the `didUpdateBuildContext` is called again
+/// by the widget_driver framework.
+///
+/// To make it easy to test this you can use this class like this:
+///
+/// ```dart
+/// ValueNotifier<int> fakeCountNotifier = ValueNotifier<int>(0);
+/// ...
+/// final driverTester = await tester.getDriverTester(
+///     driverBuilder: () => CounterDriver(),
+///     parentWidgetBuilder: (driverWidget) {
+///         return UpdatableDependency<int>(
+///             valueNotifier: fakeCountNotifier,
+///             builder: (count) {
+///               return Provider<int>.value(value: count, child: driverWidget);
+///             }
+///         );
+///     },
+/// );
+///
+/// // The initial value was '0' when the driver was created.
+/// expect(driverTester.driver.counterText, '0');
+///
+/// // Update the counter value and make flutter "render" the changes.
+/// fakeCountNotifier.value = 123;
+/// await tester.pumpAndSettle();
+///
+/// // Now the `didUpdateBuildContext` was called with value 123 so now the text will be '123'
+/// expect(driverTester.driver.counterText, '123');
+/// ```
+class UpdatableDependency<T> extends StatelessWidget {
+  final ValueNotifier<T> valueNotifier;
+  final Widget Function(T value) builder;
+
+  const UpdatableDependency({
+    Key? key,
+    required this.valueNotifier,
+    required this.builder,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<T>(
+      builder: (BuildContext context, T value, _) {
+        return builder(value);
+      },
+      valueListenable: valueNotifier,
+    );
+  }
+}

--- a/widget_driver_test/lib/widget_driver_test.dart
+++ b/widget_driver_test/lib/widget_driver_test.dart
@@ -3,3 +3,4 @@ library widget_driver_test;
 export 'src/driver_tester.dart';
 export 'src/mock_driver.dart';
 export 'src/widget_tester_extension.dart';
+export 'src/updatable_dependency.dart';

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widget_driver: ^0.2.0
+  widget_driver: ^0.3.0
   mocktail: ^0.1.4
   meta: ^1.7.0
   test: ^1.16.0

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_test
 description: Contains helper classes/methods for DrivableWidgets, WidgetDrivers, helps with TestDrivers mocking
-version: 0.1.0
+version: 0.2.0
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_test
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 


### PR DESCRIPTION
## Description
Adds a new helper widget you can use in your driver tests to test the `didUpdateBuildContext` of your drivers.

Solves issue #126

## Type of Change

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
