### PR TITLE
Adds didInitDriver method to driver

### DIFF
--- a/widget_driver/CHANGELOG.md
+++ b/widget_driver/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0
 
 * Changes name of `DependencyProvider` to `DependencyResolver` and adds support in it for resolving dependencies using the BuildContext.
+* Adds a `didInitDriver` method to the driver which is called one time per `Driver` lifecycle after the driver is fully initialized.
 
 ## 0.2.0
 

--- a/widget_driver/lib/src/drivable_widget.dart
+++ b/widget_driver/lib/src/drivable_widget.dart
@@ -92,6 +92,8 @@ class _DriverWidgetState<Driver extends WidgetDriver> extends State<DrivableWidg
       }
     });
 
+    driver.didInitDriver();
+
     _driver = driver;
     return driver;
   }

--- a/widget_driver/lib/src/widget_driver.dart
+++ b/widget_driver/lib/src/widget_driver.dart
@@ -84,6 +84,19 @@ abstract class WidgetDriver {
     }
   }
 
+  /// Called when this driver is fully initialized.
+  /// This means that the constructor has been called
+  /// and the [didUpdateBuildContext] was called one time.
+  ///
+  /// So any `late` dependency setup you did in either the constructor or the [didUpdateBuildContext]
+  /// has now been completed and your driver has access to all its initial data.
+  ///
+  /// The framework will call this method exactly once for each [WidgetDriver] object
+  /// it creates.
+  ///
+  /// Override this method to perform initialization work which you want to run only one time per [WidgetDriver].
+  void didInitDriver() {}
+
   /// If the [WidgetDriver] needs a dependency from
   /// the [BuildContext] then you can override this method.
   ///
@@ -126,6 +139,8 @@ class TestDriver {
   void notifyWidget() {}
 
   void dispose() {}
+
+  void didInitDriver() {}
 
   void didUpdateBuildContext(BuildContext context) {}
 }


### PR DESCRIPTION
## Description
Adds a didInitDriver optional override method to Drivers.
You can implement it if you need to do some one-time setup work in your driver.

That method is called one time per driver lifecycle.

It is called directly after the `didUpdateBuildContext` has been called for the first time.

## Type of Change

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
