### PR TITLE
Add WidgetDriver logo to all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-# WidgetDriver
+<div align="center" style="margin-bottom: 15px;">
+  <img src="https://github.com/bmw-tech/widget_driver/blob/master/widget_driver/doc/resources/widget_driver_logo.png?raw=true" style="max-width: 170px">
+</div>
+
+<div align="center" style="margin-bottom: 15px;">
 
 [![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
+</div>
 
-A Flutter presentation layer framework,  
+`WidgetDriver` is a Flutter presentation layer framework,  
 which will clean up your widget code, make your widgets more maintainable and easier to test, and removes the need to mock thousands of dependencies in your widget tests.  
 Let's go driving! 🚙💨
 

--- a/widget_driver/README.md
+++ b/widget_driver/README.md
@@ -10,7 +10,7 @@
 
 </div>
 
-A Flutter presentation layer framework,  
+`WidgetDriver` is a Flutter presentation layer framework,  
 which will clean up your widget code, make your widgets more maintainable and easier to test, and removes the need to mock thousands of dependencies in your widget tests.  
 Let's go driving! 🚙💨
 

--- a/widget_driver_annotation/CHANGELOG.md
+++ b/widget_driver_annotation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.1
+
+* Adds the WidgetDriver logo to the readme 🥳
+
 ## 1.0.0
 
 * No changes. Just the official release of WidgetDriverAnnotations :-D

--- a/widget_driver_annotation/README.md
+++ b/widget_driver_annotation/README.md
@@ -1,9 +1,15 @@
-# WidgetDriver annotation
+<div align="center" style="margin-bottom: 15px;">
+  <img src="https://github.com/bmw-tech/widget_driver/blob/master/widget_driver/doc/resources/widget_driver_logo.png?raw=true" style="max-width: 170px">
+</div>
+
+<div align="center" style="margin-bottom: 15px;">
 
 [![pub package](https://img.shields.io/pub/v/widget_driver_annotation.svg)](https://pub.dev/packages/widget_driver_annotation)
 [![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
 
-Defines the annotations used by `widget_driver` and `widget_driver_generator` to create code for your `WidgetDrivers`.
+</div>
+
+`widget_driver_annotation` defines the annotations used by `widget_driver` and `widget_driver_generator` to create code for your `WidgetDrivers`.
 
 See the documentation for [widget_driver](../widget_driver) to understand how there annotations work and how you can configure and use them.

--- a/widget_driver_annotation/pubspec.yaml
+++ b/widget_driver_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_annotation
 description: Defines the annotations used by widget_driver and widget_driver_generator to create code for your WidgetDrivers
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_annotation
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 

--- a/widget_driver_generator/CHANGELOG.md
+++ b/widget_driver_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.1
+
+* Adds the WidgetDriver logo to the readme 🥳
+
 ## 1.0.0
 
 * No changes. Just the official release of WidgetDriverGenerator :-D

--- a/widget_driver_generator/README.md
+++ b/widget_driver_generator/README.md
@@ -1,10 +1,16 @@
-# WidgetDriver generator
+<div align="center" style="margin-bottom: 15px;">
+  <img src="https://github.com/bmw-tech/widget_driver/blob/master/widget_driver/doc/resources/widget_driver_logo.png?raw=true" style="max-width: 170px">
+</div>
+
+<div align="center" style="margin-bottom: 15px;">
 
 [![pub package](https://img.shields.io/pub/v/widget_driver_generator.svg)](https://pub.dev/packages/widget_driver_generator)
 [![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
 
-This is a helper package that supports the `widget_driver` package and generates the bootstrapping code needed to get your `Drivers` fully set up.
+</div>
+
+`widget_driver_generator` is a helper package that supports the `widget_driver` package and generates the bootstrapping code needed to get your `Drivers` fully set up.
 
 ---
 

--- a/widget_driver_generator/pubspec.yaml
+++ b/widget_driver_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_generator
 description: This package provides generators for WidgetDriver to automate the creation of your TestDrivers and WidgetDriverProviders
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_generator
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 

--- a/widget_driver_test/CHANGELOG.md
+++ b/widget_driver_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Adds the WidgetDriver logo to the readme 🥳
+
 ## 1.0.0
 
 * The official release of WidgetDriverTest :-D

--- a/widget_driver_test/README.md
+++ b/widget_driver_test/README.md
@@ -1,11 +1,16 @@
-# WidgetDriver test
+<div align="center" style="margin-bottom: 15px;">
+  <img src="https://github.com/bmw-tech/widget_driver/blob/master/widget_driver/doc/resources/widget_driver_logo.png?raw=true" style="max-width: 170px">
+</div>
+
+<div align="center" style="margin-bottom: 15px;">
 
 [![pub package](https://img.shields.io/pub/v/widget_driver_test.svg)](https://pub.dev/packages/widget_driver_test)
 [![check-code-quality](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml/badge.svg?branch=master)](https://github.com/bmw-tech/widget_driver/actions/workflows/check-code-quality.yml)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
 
-A package that makes testing `WidgetDrivers` and `DrivableWidgets` easy.  
-Built to work with mocktail for easy mocking.
+</div>
+
+`widget_driver_test` is a package that makes testing `WidgetDrivers` and `DrivableWidgets` easy. Built to work with mocktail for easy mocking.
 
 To learn more about `WidgetDrivers` then please read the documentation for [widget_driver](../widget_driver).
 

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_test
 description: Contains helper classes/methods for DrivableWidgets, WidgetDrivers, helps with TestDrivers mocking
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_test
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 


### PR DESCRIPTION
## Description
In the last commit we only added the WidgetDriver logo to the widget_driver package. 
But not to all the other packages. This commit fixes that and applies to logo to all READMEs.

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [x] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
