### PR TITLE
Adds support for dart sdk 3.0.0

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -21,9 +21,9 @@ jobs:
       - name: prepare flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.3.4'
+          flutter-version: '3.10.0'
           channel: 'stable'
       - name: Run quality checks if pipeline label was set
         run: |
-          git config --global --add safe.directory /opt/hostedtoolcache/flutter/stable-3.3.4-x64
+          git config --global --add safe.directory /opt/hostedtoolcache/flutter/stable-3.10.0-x64
           make quality

--- a/scripts/run-example-run-build-runner.sh
+++ b/scripts/run-example-run-build-runner.sh
@@ -8,4 +8,4 @@ TAG_COLOR="\n${GREEN}${TAG}${NC}"
 echo -e "$TAG_COLOR Generating code in example: $project_folder"
 cd widget_driver/example
 flutter pub get
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -16,7 +16,7 @@ function run_tests() {
         # allowed in flutter
         dart test --coverage coverage || exit $?
     else
-        flutter test --coverage --no-pub --no-test-assets --no-track-widget-creation --no-sound-null-safety || exit $?
+        flutter test --coverage --no-pub --no-test-assets --no-track-widget-creation || exit $?
     fi
     cd $current_dir
 }

--- a/widget_driver_annotation/CHANGELOG.md
+++ b/widget_driver_annotation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.2
+
+* Adds and bumps support for SDK constraint to 3.0.0.
+
 ## 1.0.1
 
 * Adds the WidgetDriver logo to the readme 🥳

--- a/widget_driver_annotation/pubspec.yaml
+++ b/widget_driver_annotation/pubspec.yaml
@@ -1,11 +1,11 @@
 name: widget_driver_annotation
 description: Defines the annotations used by widget_driver and widget_driver_generator to create code for your WidgetDrivers
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_annotation
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ^3.0.0
 
 dev_dependencies:
   test: ^1.22.2


### PR DESCRIPTION
## Description
We only supported dart sdk versions up to, but not including, 3.0.0.
So any project using flutter 3.10 or later would have issues.

This PR just changes so that the newer version of this package support all version from 3.0.0 up until <4.0.0

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [x] 🧹 Chore / Housekeeping
