### PR TITLE
Updates the format of min sdk definition

### DIFF
--- a/widget_driver_annotation/pubspec.yaml
+++ b/widget_driver_annotation/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   test: ^1.22.2


### PR DESCRIPTION
## Description
Seems the `^` format is not allowed when specifying the min sdk.
I got this warning when trying to publish the package:

```
Package validation found the following error:
* ^ version constraints aren't allowed for SDK constraints since older versions of pub don't support them.
  Expand it manually instead:
  
  environment:
    sdk: ">=3.0.0 <4.0.0"
```

So I changed it and I hope this works.
Running the `dart publish --dry-run` does not really help. Since it also didn't complain before.
So I am not 100% sure this will fix it.. But lets see 😄 🤞 

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
