### PR TITLE
Adds support for dart sdk 3.0.0 to widget_driver and widget_driver_generator

### DIFF
--- a/widget_driver/CHANGELOG.md
+++ b/widget_driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.5
+
+* Adds SDK constraint to 3.0.0.
+
 ## 1.0.4
 
 * Adds the WidgetDriver logo to the readme 🥳

--- a/widget_driver/README.md
+++ b/widget_driver/README.md
@@ -221,7 +221,7 @@ Read more about that [here](doc/drivers_without_generation.md)*
 At the root of your flutter project, run this command:
 
 ```bash
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 ```
 
 When the build runner completes then we are ready to start building our widget

--- a/widget_driver/doc/code_generation.md
+++ b/widget_driver/doc/code_generation.md
@@ -34,6 +34,6 @@ This is pretty easy. It basically just contains two steps:
 
 2. Run the build runner:  
     ```console
-    flutter pub run build_runner build --delete-conflicting-outputs
+    dart run build_runner build --delete-conflicting-outputs
     ```
     Read more about using the `build_runner` [here](https://pub.dev/packages/build_runner).

--- a/widget_driver/example/example.md
+++ b/widget_driver/example/example.md
@@ -73,7 +73,7 @@ Run the WidgetDriver code generator.
 At the root of your flutter project, run this command:
 
 ```bash
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 ```
 
 ### 4. Create your Drivable Widget

--- a/widget_driver/pubspec.yaml
+++ b/widget_driver/pubspec.yaml
@@ -1,18 +1,18 @@
 name: widget_driver
 description: A Flutter presentation layer framework, which will clean up your widget code and make your widgets testable without a need for thousands of mock objects. Let's go driving!
-version: 1.0.4
+version: 1.0.5
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
-  flutter: ">=2.6.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  widget_driver_annotation: ^1.0.0
+  widget_driver_annotation: ^1.0.2
 
 dev_dependencies:
   flutter_test:

--- a/widget_driver_generator/CHANGELOG.md
+++ b/widget_driver_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.2
+
+* Adds SDK constraint to 3.0.0.
+
 ## 1.0.1
 
 * Adds the WidgetDriver logo to the readme 🥳

--- a/widget_driver_generator/README.md
+++ b/widget_driver_generator/README.md
@@ -90,7 +90,7 @@ So now you have all of your imports, definitions and annotations in place.
 Then let's do a one-time build:
 
 ```console
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 ```
 
 Read more about using

--- a/widget_driver_generator/example/README.md
+++ b/widget_driver_generator/example/README.md
@@ -64,5 +64,5 @@ This works with named, positional and/or optional variables.
 In order to generate TestDrivers and WidgetDriverProviders just run this command:
 
 ```console
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 ```

--- a/widget_driver_generator/pubspec.yaml
+++ b/widget_driver_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_generator
 description: This package provides generators for WidgetDriver to automate the creation of your TestDrivers and WidgetDriverProviders
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_generator
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
@@ -10,13 +10,13 @@ platforms:
   windows:
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   build: ^2.0.0
   source_gen: ^1.0.0
-  analyzer: ^4.7.0
-  widget_driver_annotation: ^1.0.0
+  analyzer: ^5.13.0
+  widget_driver_annotation: ^1.0.2
 
 dev_dependencies:
   build_runner: ^2.0.0


### PR DESCRIPTION
## Description
We only supported dart sdk versions up to, but not including, 3.0.0.
So any project using flutter 3.10 or later would have issues.

This PR just changes so that the newer version of this package support all version from 3.0.0 up until <4.0.0
This change is now for the widget_driver and the widget_driver_generator.

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
