### PR TITLE
Adds support for dart sdk 3.0.0 to widget_driver_test and example app

### DIFF
--- a/widget_driver/example/README.md
+++ b/widget_driver/example/README.md
@@ -40,7 +40,7 @@ The example app will show you how to use both approaches.
 To generate the needed `WidgetDriver` code then run this command from the root folder of the example app:
 
 ```shell
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 ```
 
 ## Testing

--- a/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.g.dart
+++ b/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.g.dart
@@ -8,7 +8,7 @@ part of 'my_first_drivable_widget_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestMyFirstDrivableWidgetDriver extends TestDriver implements MyFirstDrivableWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_community_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestCoffeeCommunityPageDriver extends TestDriver implements CoffeeCommunityPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_detail_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestCoffeeDetailPageDriver extends TestDriver implements CoffeeDetailPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_library_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestCoffeeLibraryPageDriver extends TestDriver implements CoffeeLibraryPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'not_logged_in_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestNotLoggedInPageDriver extends TestDriver implements NotLoggedInPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'register_account_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestRegisterAccountPageDriver extends TestDriver implements RegisterAccountPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_counter_header_section_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestCoffeeCounterHeaderSectionDriver extends TestDriver implements CoffeeCounterHeaderSectionDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_counter_widget_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestCoffeeCounterWidgetDriver extends TestDriver implements CoffeeCounterWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
@@ -8,7 +8,7 @@ part of 'random_coffee_image_widget_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestRandomCoffeeImageWidgetDriver extends TestDriver implements RandomCoffeeImageWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'home_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestHomePageDriver extends TestDriver implements HomePageDriver {
   @override

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
@@ -8,7 +8,7 @@ part of 'log_in_out_button_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestLogInOutButtonDriver extends TestDriver implements LogInOutButtonDriver {
   @override

--- a/widget_driver/example/lib/widgets/my_app_driver.g.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.g.dart
@@ -8,7 +8,7 @@ part of 'my_app_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "0.3.0"
+// This file was generated with widget_driver_generator version "1.0.2"
 
 class _$TestMyAppDriver extends TestDriver implements MyAppDriver {
   @override

--- a/widget_driver/example/pubspec.yaml
+++ b/widget_driver/example/pubspec.yaml
@@ -4,14 +4,14 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
-  flutter: ">=2.6.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  widget_driver: ^1.0.0
+  widget_driver: ^1.0.5
   meta: ^1.7.0
   get_it: ^7.2.0
   provider: ^6.0.4
@@ -26,7 +26,7 @@ dev_dependencies:
   widget_driver_test:
     path: ../../widget_driver_test
   build_runner:
-  widget_driver_generator: ^1.0.0
+  widget_driver_generator: ^1.0.2
 
 flutter:
   uses-material-design: true

--- a/widget_driver_test/CHANGELOG.md
+++ b/widget_driver_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+* Adds SDK constraint to 3.0.0.
+
 ## 1.0.1
 
 * Adds the WidgetDriver logo to the readme 🥳

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -1,19 +1,19 @@
 name: widget_driver_test
 description: Contains helper classes/methods for DrivableWidgets, WidgetDrivers, helps with TestDrivers mocking
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_test
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  widget_driver: ^1.0.0
+  widget_driver: ^1.0.5
   mocktail: ^0.1.4
   meta: ^1.7.0
-  test: ^1.16.0
+  test: ^1.22.2
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
## Description
We only supported dart sdk versions up to, but not including, 3.0.0.
So any project using flutter 3.10 or later would have issues.

This PR just changes so that the newer version of this package support all version from 3.0.0 up until <4.0.0
This updates the widget_driver_tests and the example app

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
