### PR TITLE
Add testConfigProvider to control use of test drivers

### DIFF
--- a/widget_driver/CHANGELOG.md
+++ b/widget_driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.8
+
+* Adds a new `WidgetDriverTestConfigProvider` which you can use in your widget tests to control if a test driver or a real driver should be used.
+
 ## 1.0.7
 
 * Make readme images darkmode compatible

--- a/widget_driver/doc/testing.md
+++ b/widget_driver/doc/testing.md
@@ -61,6 +61,32 @@ And that is it! Wow!
 Now your widgetTests can get back to focus on testing your widget. 
 And they can stop being mock-factories 😄
 
+### Use real drivers in your DrivableWidgets
+
+In case you have some special use case where you actually don't want to use `TestDrivers` then you can use the `WidgetDriverTestConfigProvider`. It gives you the possibility to control if a TestDriver or a real driver is created for each `DrivableWidget`. Just wrap the widget under tests inside a `WidgetDriverTestConfigProvider`.
+
+If you want to use real drivers for all `DrivableWidgets` in a test, then you can do this:
+
+```dart
+final myWidget = WidgetDriverTestConfigProvider(
+  config: AlwaysUseRealDriversTestConfig(),
+  child: MyWidget(),
+);
+await tester.pumpWidget(myWidget);
+```
+
+If you only want to use real drivers for some of your `DrivableWidgets`, then you can do this:
+
+```dart
+final myWidget = WidgetDriverTestConfigProvider(
+  config: UseRealDriversForSomeTestConfig(
+    useRealDriversFor: { MyWidgetDriver }
+  ),
+  child: MyWidget(),
+);
+await tester.pumpWidget(myWidget);
+```
+
 ## Testing WidgetDrivers
 
 Okay, so now you know how to test these new widgets.  

--- a/widget_driver/lib/src/drivable_widget.dart
+++ b/widget_driver/lib/src/drivable_widget.dart
@@ -6,6 +6,7 @@ import 'mock_driver_provider.dart';
 import 'utils/runtime_environment_info.dart';
 import 'widget_driver.dart';
 import 'widget_driver_provider.dart';
+import 'widget_driver_test_config.dart';
 
 export 'package:flutter/widgets.dart' show BuildContext;
 
@@ -78,7 +79,7 @@ class _DriverWidgetState<Driver extends WidgetDriver> extends State<DrivableWidg
     }
 
     Driver driver;
-    if (_isRunningInTestEnvironment()) {
+    if (_isRunningInTestEnvironment() && _testingConfigAllowsTestDriver()) {
       driver = _getTestDriver();
     } else {
       driver = _getRealDriver();
@@ -125,6 +126,16 @@ class _DriverWidgetState<Driver extends WidgetDriver> extends State<DrivableWidg
   }
 
   bool get _driverExists => _driver != null;
+
+  bool _testingConfigAllowsTestDriver() {
+    // You can use the WidgetDriverTestConfigProvider to make custom
+    // overrides and disable the use of TestDrivers in some cases if needed.
+    final testConfig = WidgetDriverTestConfigProvider.of(context);
+    if (testConfig != null) {
+      return testConfig.useTestDriver<Driver>();
+    }
+    return true;
+  }
 }
 
 class _WidgetDriverContainer<Driver extends WidgetDriver> {

--- a/widget_driver/lib/src/widget_driver_test_config.dart
+++ b/widget_driver/lib/src/widget_driver_test_config.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/widgets.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+/// A widget you can use to provide a test configuration to your [DrivableWidget]s when you are testing them.
+///
+/// When your widget is being tested and you provided a test config using the [WidgetDriverTestConfigProvider]
+/// then that test config will be used by the [WidgetDriver] framework to decide how to set up your Drivers.
+///
+/// Here is an example of how you can use this in your [WidgetTests] to use real drivers for all Drivers:
+///
+/// ```dart
+/// final myWidget = WidgetDriverTestConfigProvider(
+///    config: AlwaysUseRealDriversTestConfig(),
+///    child: MyWidget(),
+/// );
+/// ...
+/// await tester.pumpWidget(myWidget);
+/// ```
+///
+/// And here is an example of how you can use this in your [WidgetTests] to use real drivers for some Drivers:
+///
+/// ```dart
+/// final myWidget = WidgetDriverTestConfigProvider(
+///    config: UseRealDriversForSomeTestConfig(useRealDriversFor: {MyWidgetDriver}),
+///    child: MyWidget(),
+/// );
+/// ...
+/// await tester.pumpWidget(myWidget);
+/// ```
+///
+@visibleForTesting
+class WidgetDriverTestConfigProvider extends InheritedWidget {
+  const WidgetDriverTestConfigProvider({
+    Key? key,
+    required WidgetDriverTestConfig config,
+    required Widget child,
+  })  : _config = config,
+        super(key: key, child: child);
+
+  final WidgetDriverTestConfig _config;
+
+  /// Resolves the test config out from the [BuildContext].
+  /// If no test config was provided, then it returns `null`
+  static WidgetDriverTestConfig? of(BuildContext context) {
+    final testConfigProvider = context.dependOnInheritedWidgetOfExactType<WidgetDriverTestConfigProvider>();
+    return testConfigProvider?._config;
+  }
+
+  @override
+  bool updateShouldNotify(WidgetDriverTestConfigProvider oldWidget) {
+    return oldWidget._config != _config;
+  }
+}
+
+/// Base class for defining test configuration for the [WidgetDriver] framework which is used during testing.
+@visibleForTesting
+abstract class WidgetDriverTestConfig {
+  bool useTestDriver<Driver extends WidgetDriver>();
+}
+
+/// Use this class in your WidgetDriver tests to always use real drivers and never use any test drivers.
+@visibleForTesting
+class AlwaysUseRealDriversTestConfig implements WidgetDriverTestConfig {
+  @override
+  bool useTestDriver<Driver extends WidgetDriver>() => false;
+}
+
+/// Use this class in your WidgetDriver tests to use real drivers for some drivers.
+/// You can specify for which drivers you want to use the real driver by passing
+/// in the Type of these drivers into the `useRealDriversFor` parameter.
+///
+/// For example, if you only want to use the real driver for a driver class named `MyCoolDriver`,
+/// then you would type this:
+///
+/// ```dart
+/// UseRealDriversForSomeTestConfig(useRealDriversFor: {MyCoolDriver})
+/// ```
+///
+/// Then any driver created during the testing will use a [TestDriver] unless the driver is of type `MyCoolDriver`.
+/// For all the `MyCoolDriver`, the real `MyCoolDriver` driver will be used instead.
+@visibleForTesting
+class UseRealDriversForSomeTestConfig implements WidgetDriverTestConfig {
+  UseRealDriversForSomeTestConfig({
+    required Set<Type> useRealDriversFor,
+  }) : _useRealDriverForTheseDrivers = useRealDriversFor;
+
+  final Set<Type> _useRealDriverForTheseDrivers;
+
+  @override
+  bool useTestDriver<Driver extends WidgetDriver>() {
+    if (_useRealDriverForTheseDrivers.contains(Driver)) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/widget_driver/lib/widget_driver.dart
+++ b/widget_driver/lib/widget_driver.dart
@@ -7,5 +7,6 @@ export 'src/mock_driver_provider.dart';
 export 'src/utils/runtime_environment_info.dart';
 export 'src/utils/empty_default.dart';
 export 'src/dependency_resolver.dart';
+export 'src/widget_driver_test_config.dart';
 
 export 'package:widget_driver_annotation/widget_driver_annotation.dart';

--- a/widget_driver/pubspec.yaml
+++ b/widget_driver/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver
 description: A Flutter presentation layer framework, which will clean up your widget code and make your widgets testable without a need for thousands of mock objects. Let's go driving!
-version: 1.0.7
+version: 1.0.8
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 

--- a/widget_driver/test/test_helpers/build_context_provider.dart
+++ b/widget_driver/test/test_helpers/build_context_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A helper class which you can use when you need access to a build context in your tests
+class BuildContextProvider {
+  WidgetTester widgetTester;
+  Widget Function(Widget childWidget)? dependencyProviderWidget;
+
+  BuildContextProvider(this.widgetTester, {this.dependencyProviderWidget});
+
+  Future<void> performAction(void Function(BuildContext context) contextProvidingCallback) async {
+    Widget Function(Widget childWidget) widgetBuilder;
+    if (dependencyProviderWidget != null) {
+      widgetBuilder = dependencyProviderWidget!;
+    } else {
+      widgetBuilder = (childWidget) {
+        return Container(child: childWidget);
+      };
+    }
+
+    final contextProvidingWidget = Builder(builder: (context) {
+      contextProvidingCallback(context);
+      return Container();
+    });
+
+    final widget = widgetBuilder(contextProvidingWidget);
+    await widgetTester.pumpWidget(widget);
+  }
+}

--- a/widget_driver/test/widget_driver_test_config_test.dart
+++ b/widget_driver/test/widget_driver_test_config_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import 'test_helpers/build_context_provider.dart';
+
+void main() {
+  group('WidgetDriverTestConfigProvider:', () {
+    testWidgets('Returns test config when it is provided', (WidgetTester tester) async {
+      final buildContextProvider = BuildContextProvider(
+        tester,
+        dependencyProviderWidget: (childWidget) => WidgetDriverTestConfigProvider(
+          config: AlwaysUseRealDriversTestConfig(),
+          child: childWidget,
+        ),
+      );
+
+      await buildContextProvider.performAction((context) {
+        final testConfig = WidgetDriverTestConfigProvider.of(context);
+        expect(testConfig, isNotNull);
+        expect(testConfig is AlwaysUseRealDriversTestConfig, isTrue);
+      });
+    });
+
+    testWidgets('Returns null when no test config is provided', (WidgetTester tester) async {
+      final buildContextProvider = BuildContextProvider(
+        tester,
+        dependencyProviderWidget: (childWidget) => childWidget,
+      );
+
+      await buildContextProvider.performAction((context) {
+        final testConfig = WidgetDriverTestConfigProvider.of(context);
+        expect(testConfig, isNull);
+      });
+    });
+  });
+
+  group('AlwaysUseRealDriversTestConfig:', () {
+    test('returns false for useTestDriver', () {
+      final testConfig = AlwaysUseRealDriversTestConfig();
+      expect(testConfig.useTestDriver(), isFalse);
+    });
+  });
+
+  group('UseRealDriversForSomeTestConfig:', () {
+    test('returns false for useTestDriver when driver should use real driver', () {
+      final testConfig = UseRealDriversForSomeTestConfig(useRealDriversFor: {_TestDriver1});
+      expect(testConfig.useTestDriver<_TestDriver1>(), isFalse);
+    });
+
+    test('returns true for useTestDriver when driver should not use real driver', () {
+      final testConfig = UseRealDriversForSomeTestConfig(useRealDriversFor: {_TestDriver1});
+      expect(testConfig.useTestDriver<_TestDriver2>(), isTrue);
+    });
+  });
+}
+
+class _TestDriver1 extends WidgetDriver {}
+
+class _TestDriver2 extends WidgetDriver {}


### PR DESCRIPTION
## Description

There might be times when you actually want to use the real drivers when testing your DrivableWidgets.
This PR adds a `WidgetDriverTestConfigProvider` which you can use to control the config used during testing.
More specifically it gives you the option to control if you:

- always want to use the real drivers for a given test.
- use real drives for a specified list of drivers for a given test.

This PR solves Issue #152

## Type of Change

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [x] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
