### PR TITLE
Updates example app and widget_driver_test with latest info about TestConfigProvider

### DIFF
--- a/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.g.dart
+++ b/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.g.dart
@@ -8,7 +8,7 @@ part of 'my_first_drivable_widget_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestMyFirstDrivableWidgetDriver extends TestDriver implements MyFirstDrivableWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_community_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestCoffeeCommunityPageDriver extends TestDriver implements CoffeeCommunityPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_detail_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestCoffeeDetailPageDriver extends TestDriver implements CoffeeDetailPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_library_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestCoffeeLibraryPageDriver extends TestDriver implements CoffeeLibraryPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'not_logged_in_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestNotLoggedInPageDriver extends TestDriver implements NotLoggedInPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'register_account_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestRegisterAccountPageDriver extends TestDriver implements RegisterAccountPageDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_counter_header_section_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestCoffeeCounterHeaderSectionDriver extends TestDriver implements CoffeeCounterHeaderSectionDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
@@ -8,7 +8,7 @@ part of 'coffee_counter_widget_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestCoffeeCounterWidgetDriver extends TestDriver implements CoffeeCounterWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
@@ -8,7 +8,7 @@ part of 'random_coffee_image_widget_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestRandomCoffeeImageWidgetDriver extends TestDriver implements RandomCoffeeImageWidgetDriver {
   @override

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
@@ -8,7 +8,7 @@ part of 'home_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestHomePageDriver extends TestDriver implements HomePageDriver {
   @override

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
@@ -8,7 +8,7 @@ part of 'log_in_out_button_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestLogInOutButtonDriver extends TestDriver implements LogInOutButtonDriver {
   @override

--- a/widget_driver/example/lib/widgets/my_app_driver.g.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.g.dart
@@ -8,7 +8,7 @@ part of 'my_app_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.0.2"
+// This file was generated with widget_driver_generator version "1.0.3"
 
 class _$TestMyAppDriver extends TestDriver implements MyAppDriver {
   @override

--- a/widget_driver/example/lib/widgets/playground/playground_page.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_page.dart
@@ -1,10 +1,17 @@
 import 'package:flutter/material.dart';
 
+import 'playground_test_widget/playground_test_widget.dart';
+
 class PlaygroundPage extends StatelessWidget {
   const PlaygroundPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text('Put your fun playground test code here'));
+    return Column(
+      children: [
+        const Center(child: Text('Put your fun playground test code here')),
+        PlaygroundTestWidget(),
+      ],
+    );
   }
 }

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import 'playground_test_child_widget_driver.dart';
+
+class PlaygroundTestChildWidget extends DrivableWidget<PlaygroundTestChildWidgetDriver> {
+  PlaygroundTestChildWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(driver.theText);
+  }
+
+  @override
+  WidgetDriverProvider<PlaygroundTestChildWidgetDriver> get driverProvider =>
+      $PlaygroundTestChildWidgetDriverProvider();
+}

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.dart
@@ -1,0 +1,9 @@
+import 'package:widget_driver/widget_driver.dart';
+
+part 'playground_test_child_widget_driver.g.dart';
+
+@GenerateTestDriver()
+class PlaygroundTestChildWidgetDriver extends WidgetDriver {
+  @TestDriverDefaultValue('Text coming from TestDriver')
+  String get theText => 'Text coming from RealDriver';
+}

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'playground_test_child_widget_driver.dart';
+
+// **************************************************************************
+// WidgetDriverGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+
+// This file was generated with widget_driver_generator version "1.0.3"
+
+class _$TestPlaygroundTestChildWidgetDriver extends TestDriver implements PlaygroundTestChildWidgetDriver {
+  @override
+  String get theText => 'Text coming from TestDriver';
+}
+
+class $PlaygroundTestChildWidgetDriverProvider extends WidgetDriverProvider<PlaygroundTestChildWidgetDriver> {
+  @override
+  PlaygroundTestChildWidgetDriver buildDriver() {
+    return PlaygroundTestChildWidgetDriver();
+  }
+
+  @override
+  PlaygroundTestChildWidgetDriver buildTestDriver() {
+    return _$TestPlaygroundTestChildWidgetDriver();
+  }
+}

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import 'playground_test_child_widget.dart';
+import 'playground_test_widget_driver.dart';
+
+class PlaygroundTestWidget extends DrivableWidget<PlaygroundTestWidgetDriver> {
+  PlaygroundTestWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Container(
+        decoration: const BoxDecoration(
+          borderRadius: BorderRadius.all(Radius.circular(8)),
+          color: Colors.lightBlue,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            children: [
+              Text(driver.buttonHeaderText),
+              ElevatedButton(
+                onPressed: () {
+                  // ignore: avoid_print
+                  print('Tap tap');
+                },
+                child: PlaygroundTestChildWidget(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  WidgetDriverProvider<PlaygroundTestWidgetDriver> get driverProvider => $PlaygroundTestWidgetDriverProvider();
+}

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.dart
@@ -1,0 +1,9 @@
+import 'package:widget_driver/widget_driver.dart';
+
+part 'playground_test_widget_driver.g.dart';
+
+@GenerateTestDriver()
+class PlaygroundTestWidgetDriver extends WidgetDriver {
+  @TestDriverDefaultValue('Button header text from TestDriver')
+  String get buttonHeaderText => 'Button header text from RealDriver';
+}

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'playground_test_widget_driver.dart';
+
+// **************************************************************************
+// WidgetDriverGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+
+// This file was generated with widget_driver_generator version "1.0.3"
+
+class _$TestPlaygroundTestWidgetDriver extends TestDriver implements PlaygroundTestWidgetDriver {
+  @override
+  String get buttonHeaderText => 'Button header text from TestDriver';
+}
+
+class $PlaygroundTestWidgetDriverProvider extends WidgetDriverProvider<PlaygroundTestWidgetDriver> {
+  @override
+  PlaygroundTestWidgetDriver buildDriver() {
+    return PlaygroundTestWidgetDriver();
+  }
+
+  @override
+  PlaygroundTestWidgetDriver buildTestDriver() {
+    return _$TestPlaygroundTestWidgetDriver();
+  }
+}

--- a/widget_driver/example/pubspec.yaml
+++ b/widget_driver/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  widget_driver: ^1.0.5
+  widget_driver: ^1.0.8
   meta: ^1.7.0
   get_it: ^7.2.0
   provider: ^6.0.4

--- a/widget_driver/example/test/widget_tests/playground/playground_test_widget/playground_test_widget_test.dart
+++ b/widget_driver/example/test/widget_tests/playground/playground_test_widget/playground_test_widget_test.dart
@@ -1,0 +1,83 @@
+import 'package:example/widgets/playground/playground_test_widget/playground_test_child_widget.dart';
+import 'package:example/widgets/playground/playground_test_widget/playground_test_child_widget_driver.dart';
+import 'package:example/widgets/playground/playground_test_widget/playground_test_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+void main() {
+  group('PlaygroundTestWidget:', () {
+    testWidgets('Some test where we make sure the PlaygroundTestChildWidget uses real driver',
+        (WidgetTester tester) async {
+      final playgroundTestWidget = PlaygroundTestWidget();
+
+      // We wrap our `PlaygroundTestWidget` in a test config provider
+      // and say that we want a real driver for `PlaygroundTestChildWidgetDriver`.
+      final containerWidget = WidgetDriverTestConfigProvider(
+        config: UseRealDriversForSomeTestConfig(useRealDriversFor: {
+          PlaygroundTestChildWidgetDriver,
+        }),
+        child: playgroundTestWidget,
+      );
+
+      await tester.pumpWidget(MaterialApp(home: containerWidget));
+
+      // Here we are verifying that the PlaygroundTestChildWidget is using the real driver
+      expect(
+        tester.widget(find.byType(PlaygroundTestChildWidget)),
+        isA<PlaygroundTestChildWidget>().having((w) => w.driver is TestDriver, 'driver', isFalse),
+      );
+
+      // And here we verify that the PlaygroundTestWidget is using the test driver
+      expect(
+        tester.widget(find.byType(PlaygroundTestWidget)),
+        isA<PlaygroundTestWidget>().having((w) => w.driver is TestDriver, 'driver', isTrue),
+      );
+    });
+
+    testWidgets('Some test where we make sure that all drivable widgets uses real drivers',
+        (WidgetTester tester) async {
+      final playgroundTestWidget = PlaygroundTestWidget();
+
+      // We wrap our `PlaygroundTestWidget` in a test config provider
+      // and say that we want a real driver for all DrivableWidgets.
+      final containerWidget = WidgetDriverTestConfigProvider(
+        config: AlwaysUseRealDriversTestConfig(),
+        child: playgroundTestWidget,
+      );
+
+      await tester.pumpWidget(MaterialApp(home: containerWidget));
+
+      // Here we are verifying that the PlaygroundTestChildWidget is using the real driver
+      expect(
+        tester.widget(find.byType(PlaygroundTestChildWidget)),
+        isA<PlaygroundTestChildWidget>().having((w) => w.driver is TestDriver, 'driver', isFalse),
+      );
+
+      // And here we verify that the PlaygroundTestWidget is using the real driver
+      expect(
+        tester.widget(find.byType(PlaygroundTestWidget)),
+        isA<PlaygroundTestWidget>().having((w) => w.driver is TestDriver, 'driver', isFalse),
+      );
+    });
+
+    testWidgets('Some test where we do not provide test config and we always want test drivers',
+        (WidgetTester tester) async {
+      final playgroundTestWidget = PlaygroundTestWidget();
+
+      await tester.pumpWidget(MaterialApp(home: playgroundTestWidget));
+
+      // Here we are verifying that the PlaygroundTestChildWidget is using the test driver
+      expect(
+        tester.widget(find.byType(PlaygroundTestChildWidget)),
+        isA<PlaygroundTestChildWidget>().having((w) => w.driver is TestDriver, 'driver', isTrue),
+      );
+
+      // And here we verify that the PlaygroundTestWidget is using the test driver
+      expect(
+        tester.widget(find.byType(PlaygroundTestWidget)),
+        isA<PlaygroundTestWidget>().having((w) => w.driver is TestDriver, 'driver', isTrue),
+      );
+    });
+  });
+}

--- a/widget_driver_test/CHANGELOG.md
+++ b/widget_driver_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* Updates widget_driver dependency to latest 1.0.8. And updates readme with info about latest TestConfig feature.
+
 ## 1.0.3
 
 * Updates images in readme to look more "snappy" 😁

--- a/widget_driver_test/README.md
+++ b/widget_driver_test/README.md
@@ -57,6 +57,32 @@ await tester.pumpWidget(myWidget);
 // Do your widget testing now
 ```
 
+### Use real drivers in your DrivableWidgets
+
+In case you have some special use case where you actually don't want to use `TestDrivers` then you can use the `WidgetDriverTestConfigProvider`. It gives you the possibility to control if a TestDriver or a real driver is created for each `DrivableWidget`. Just wrap the widget under tests inside a `WidgetDriverTestConfigProvider`.
+
+If you want to use real drivers for all `DrivableWidgets` in a test, then you can do this:
+
+```dart
+final myWidget = WidgetDriverTestConfigProvider(
+  config: AlwaysUseRealDriversTestConfig(),
+  child: MyWidget(),
+);
+await tester.pumpWidget(myWidget);
+```
+
+If you only want to use real drivers for some of your `DrivableWidgets`, then you can do this:
+
+```dart
+final myWidget = WidgetDriverTestConfigProvider(
+  config: UseRealDriversForSomeTestConfig(
+    useRealDriversFor: { MyWidgetDriver }
+  ),
+  child: MyWidget(),
+);
+await tester.pumpWidget(myWidget);
+```
+
 ## Testing WidgetDrivers
 
 To test your `Drivers` you need your tests to use the `testWidgets` test function (just like you do when you test widgets)

--- a/widget_driver_test/README.md
+++ b/widget_driver_test/README.md
@@ -62,7 +62,7 @@ await tester.pumpWidget(myWidget);
 In case you have some special use case where you actually don't want to use `TestDrivers` then you can use the `WidgetDriverTestConfigProvider`. It gives you the possibility to control if a TestDriver or a real driver is created for each `DrivableWidget`. Just wrap the widget under tests inside a `WidgetDriverTestConfigProvider`.
 
 NOTE:  
-It really should be an exception to force the use of real driver. Since most of the time, when you are testing a DrivableWidget, then you actaully want to abstract away the real implemention logic in any child-DrivableWidget, and only focus on testing the current DrivableWidget and its direct logic.
+It really should be an exception to force the use of real drivers in your tests. Since most of the time, when you are testing a `DrivableWidget`, then you actaully want to abstract away the real implemention logic in any child `DrivableWidget`, and only focus on testing the current `DrivableWidget` and its direct logic.
 
 If you want to use real drivers for all `DrivableWidgets` in a test, then you can do this:
 

--- a/widget_driver_test/README.md
+++ b/widget_driver_test/README.md
@@ -61,6 +61,9 @@ await tester.pumpWidget(myWidget);
 
 In case you have some special use case where you actually don't want to use `TestDrivers` then you can use the `WidgetDriverTestConfigProvider`. It gives you the possibility to control if a TestDriver or a real driver is created for each `DrivableWidget`. Just wrap the widget under tests inside a `WidgetDriverTestConfigProvider`.
 
+NOTE:  
+It really should be an exception to force the use of real driver. Since most of the time, when you are testing a DrivableWidget, then you actaully want to abstract away the real implemention logic in any child-DrivableWidget, and only focus on testing the current DrivableWidget and its direct logic.
+
 If you want to use real drivers for all `DrivableWidgets` in a test, then you can do this:
 
 ```dart

--- a/widget_driver_test/pubspec.yaml
+++ b/widget_driver_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_test
 description: Contains helper classes/methods for DrivableWidgets, WidgetDrivers, helps with TestDrivers mocking
-version: 1.0.3
+version: 1.0.4
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_test
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widget_driver: ^1.0.5
+  widget_driver: ^1.0.8
   mocktail: ^0.1.4
   meta: ^1.7.0
   test: ^1.22.2


### PR DESCRIPTION
## Description
The WidgetDriver framework has a new `WidgetDriverTestConfigProvider` from version 1.0.8.
You can use this to configure how TestDrivers are used in testing.
This PR updates the example app to show case how to use these in testing.
And it also updates the README in the widget_driver_test package to contain info about this new `WidgetDriverTestConfigProvider`.

This PR completes the fix for Issue: #152 

## Type of Change

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [x] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
