### PR TITLE
[155] add default defaultTestValues for simple and frequently used types

### DIFF
--- a/widget_driver/README.md
+++ b/widget_driver/README.md
@@ -188,7 +188,7 @@ As soon as your `Driver` has new data to display, then you want to call the `not
 
     If you have a method or property which returns a future, then you can use the `@TestDriverDefaultFutureValue({default value})` instead. It will take the default value and return it as a future.
 
-   Simple return types like all of [Dart's built-in types](https://dart.dev/language/built-in-types), enums, Optionals and some frequently used types in widgets like `Color`, `IconData` and `FontWeight` are already covered. More complex types, like your custom classes, must be covered with annotations in your code. You can also optionally add annotations for any of the public fields, properties or methods with return types that are already covered. 
+   Simple return types like all of [Dart's built-in types](https://dart.dev/language/built-in-types), enums, Optionals and some frequently used types in widgets like `Color` and `IconData` are already covered. More complex types, like your custom classes, must be covered with annotations in your code. You can also optionally add annotations for any of the public fields, properties or methods with return types that are already covered. 
 
 
       ```dart

--- a/widget_driver/README.md
+++ b/widget_driver/README.md
@@ -114,18 +114,14 @@ class CounterWidgetDriver extends WidgetDriver {
     _localization = context.read<Localization>()
   }
 
-  @TestDriverDefaultValue('The title of the counter')
   String get counterTitle => _localization.counterTitle;
 
-  @TestDriverDefaultValue(1)
   int get value => _counterService.value;
 
-  @TestDriverDefaultValue()
   void increment() {
     _counterService.increment();
   }
 
-  @TestDriverDefaultValue()
   void decrement() {
     _counterService.decrement();
   }
@@ -188,23 +184,26 @@ As soon as your `Driver` has new data to display, then you want to call the `not
 
     The annotations are used by the `TestDriver` to provide default values during testing.  
 
-    For each public property and method you add the `@TestDriverDefaultValue({default value})`. As a parameter to this annotation you provide the default value which will be used in testing when other widgets create this widget.  
+    For each public property and method you may add the `@TestDriverDefaultValue({default value})`. As a parameter to this annotation you provide the default value which will be used in testing when other widgets create this widget.  
 
     If you have a method or property which returns a future, then you can use the `@TestDriverDefaultFutureValue({default value})` instead. It will take the default value and return it as a future.
 
-      ```dart
-      @TestDriverDefaultValue(1)
-      int get value => _counterService.value;
+   Simple return types like all of [Dart's built-in types](https://dart.dev/language/built-in-types), enums, Optionals and some frequently used types in widgets like `Color`, `IconData` and `FontWeight` are already covered. More complex types, like your custom classes, must be covered with annotations in your code. You can also optionally add annotations for any of the public fields, properties or methods with return types that are already covered. 
 
-      @TestDriverDefaultValue()
+
+      ```dart
+      @TestDriverDefaultValue(CustomClass())
+      CustomClass get value => _counterService.getCustomClass;
+
+      String get text => _locale.informativeText;
+
       void increment() {
         _counterService.increment();
       }
 
-      // For methods which return futures, use this annotations:
-      @TestDriverDefaultFutureValue(123)
-      Future<int> getTheNextIncrement() {
-        return _counterService.getNextIncrement();
+      @TestDriverDefaultFutureValue(CustomClass())
+      Future<CustomClass> giveMeSomeCustomClassSoon() { 
+        return _someService.getSomeCustomClassSoon();
       }
       ```
 
@@ -340,17 +339,14 @@ Easy... 🧙
           @driverProvidableProperty required Coffee coffee,
         })  : _coffee = coffee;
 
-        @TestDriverDefaultValue(TestCoffee.testCoffeeName)
         String get coffeeName {
           return '$index. ${_coffee.name}';
         }
 
-        @TestDriverDefaultValue(TestCoffee.testCoffeeDescription)
         String get coffeeDescription {
           return _coffee.description;
         }
 
-        @TestDriverDefaultValue(TestCoffee.testCoffeeImageUrl)
         String get coffeeImageUrl {
           return _coffee.imageUrl;
         }

--- a/widget_driver/doc/widget_drivers.md
+++ b/widget_driver/doc/widget_drivers.md
@@ -118,7 +118,7 @@ Any type of dependencies which your `driver` needs to be able to give your widge
 You get three option here for how to resolve these dependencies. Either you can grab them out of the `BuildContext` (for example if you are using the `Provider` package). Or you can use some DI package like `get_it` and then just grab the dependencies from the DI container. Or you can pass in the dependencies to your driver using the `@driverProvidableProperty` annotation.
 
 **Now what about those annotations?**  
-They are needed for the `testDrivers` to be generated correctly. So for properties and methods with complex return types which you expose to the widget, you will need to add these annotations. Simple return types like all of [Dart's built-in types](https://dart.dev/language/built-in-types), enums, Optionals and some frequently used types in widgets like `Color`, `IconData` and `FontWeight` are already covered.
+They are needed for the `testDrivers` to be generated correctly. So for properties and methods with complex return types which you expose to the widget, you will need to add these annotations. Simple return types like all of [Dart's built-in types](https://dart.dev/language/built-in-types), enums, Optionals and some frequently used types in widgets like `Color` and `IconData` are already covered.
 
 For properties and methods you add `@TestDriverDefaultValue({default_value})`.  
 The `default_value` should be the default value which you want to use when this widget is being created by other widgets under test.

--- a/widget_driver/doc/widget_drivers.md
+++ b/widget_driver/doc/widget_drivers.md
@@ -118,7 +118,7 @@ Any type of dependencies which your `driver` needs to be able to give your widge
 You get three option here for how to resolve these dependencies. Either you can grab them out of the `BuildContext` (for example if you are using the `Provider` package). Or you can use some DI package like `get_it` and then just grab the dependencies from the DI container. Or you can pass in the dependencies to your driver using the `@driverProvidableProperty` annotation.
 
 **Now what about those annotations?**  
-They are needed for the `testDrivers` to be generated correctly. So for all properties and methods which you expose to the widget, you will need to add these annotations.
+They are needed for the `testDrivers` to be generated correctly. So for properties and methods with complex return types which you expose to the widget, you will need to add these annotations. Simple return types like all of [Dart's built-in types](https://dart.dev/language/built-in-types), enums, Optionals and some frequently used types in widgets like `Color`, `IconData` and `FontWeight` are already covered.
 
 For properties and methods you add `@TestDriverDefaultValue({default_value})`.  
 The `default_value` should be the default value which you want to use when this widget is being created by other widgets under test.

--- a/widget_driver/example/example.md
+++ b/widget_driver/example/example.md
@@ -1,6 +1,6 @@
 # WidgetDriver quick guide
 
-## Minium steps needed to get started with WidgetDriver
+## Minimum steps needed to get started with WidgetDriver
 
 If you follow these steps then you will get this:
 <div align="left">
@@ -38,28 +38,21 @@ part 'my_first_drivable_widget_driver.g.dart';
 class MyFirstDrivableWidgetDriver extends WidgetDriver {
   int _count = 0;
 
-  @TestDriverDefaultValue('The app bar title')
   String get appBarTitle => 'Intro to WidgetDriver';
 
-  @TestDriverDefaultValue('Counter:')
   String get counterTitle => 'Counter:';
 
-  @TestDriverDefaultValue('0')
   String get counterValue => '$_count';
 
-  @TestDriverDefaultValue(Icons.add)
   IconData get increaseActionIcon => Icons.add;
 
-  @TestDriverDefaultValue(Icons.restore)
   IconData get resetActionIcon => Icons.restore;
 
-  @TestDriverDefaultValue()
   void increaseCounterAction() {
     _count += 1;
     notifyWidget();
   }
 
-  @TestDriverDefaultValue()
   void resetCounterAction() {
     _count = 0;
     notifyWidget();

--- a/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.dart
+++ b/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.dart
@@ -7,28 +7,21 @@ part 'my_first_drivable_widget_driver.g.dart';
 class MyFirstDrivableWidgetDriver extends WidgetDriver {
   int _count = 0;
 
-  @TestDriverDefaultValue('The app bar title')
   String get appBarTitle => 'Intro to WidgetDriver';
 
-  @TestDriverDefaultValue('Counter:')
   String get counterTitle => 'Counter:';
 
-  @TestDriverDefaultValue('0')
   String get counterValue => '$_count';
 
-  @TestDriverDefaultValue(Icons.add)
   IconData get increaseActionIcon => Icons.add;
 
-  @TestDriverDefaultValue(Icons.restore)
   IconData get resetActionIcon => Icons.restore;
 
-  @TestDriverDefaultValue()
   void increaseCounterAction() {
     _count += 1;
     notifyWidget();
   }
 
-  @TestDriverDefaultValue()
   void resetCounterAction() {
     _count = 0;
     notifyWidget();

--- a/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.g.dart
+++ b/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.g.dart
@@ -12,19 +12,19 @@ part of 'my_first_drivable_widget_driver.dart';
 
 class _$TestMyFirstDrivableWidgetDriver extends TestDriver implements MyFirstDrivableWidgetDriver {
   @override
-  String get appBarTitle => 'The app bar title';
+  String get appBarTitle => '';
 
   @override
-  String get counterTitle => 'Counter:';
+  String get counterTitle => '';
 
   @override
-  String get counterValue => '0';
+  String get counterValue => '';
 
   @override
-  IconData get increaseActionIcon => Icons.add;
+  IconData get increaseActionIcon => const IconData(0);
 
   @override
-  IconData get resetActionIcon => Icons.restore;
+  IconData get resetActionIcon => const IconData(0);
 
   @override
   void increaseCounterAction() {}

--- a/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.g.dart
+++ b/widget_driver/example/lib/pub_dev_example_code/my_first_drivable_widget_driver.g.dart
@@ -12,13 +12,13 @@ part of 'my_first_drivable_widget_driver.dart';
 
 class _$TestMyFirstDrivableWidgetDriver extends TestDriver implements MyFirstDrivableWidgetDriver {
   @override
-  String get appBarTitle => '';
+  String get appBarTitle => ' ';
 
   @override
-  String get counterTitle => '';
+  String get counterTitle => ' ';
 
   @override
-  String get counterValue => '';
+  String get counterValue => ' ';
 
   @override
   IconData get increaseActionIcon => const IconData(0);

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.dart
@@ -31,7 +31,6 @@ class CoffeeCommunityPageDriver extends WidgetDriver {
     });
   }
 
-  @TestDriverDefaultValue(false)
   bool get isLoggedIn => _authService.isLoggedIn;
 
   @override

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_community_page_driver.g.dart
@@ -13,6 +13,12 @@ part of 'coffee_community_page_driver.dart';
 class _$TestCoffeeCommunityPageDriver extends TestDriver implements CoffeeCommunityPageDriver {
   @override
   bool get isLoggedIn => false;
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {}
+
+  @override
+  void dispose() {}
 }
 
 class $CoffeeCommunityPageDriverProvider extends WidgetDriverProvider<CoffeeCommunityPageDriver> {

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.dart
@@ -14,17 +14,14 @@ class CoffeeDetailPageDriver extends WidgetDriver implements _$DriverProvidedPro
     @driverProvidableProperty required Coffee coffee,
   }) : _coffee = coffee;
 
-  @TestDriverDefaultValue(TestCoffee.testCoffeeName)
   String get coffeeName {
     return '$_index. ${_coffee.name}';
   }
 
-  @TestDriverDefaultValue(TestCoffee.testCoffeeDescription)
   String get coffeeDescription {
     return _coffee.description;
   }
 
-  @TestDriverDefaultValue(TestCoffee.testCoffeeImageUrl)
   String get coffeeImageUrl {
     return _coffee.imageUrl;
   }

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
@@ -12,13 +12,13 @@ part of 'coffee_detail_page_driver.dart';
 
 class _$TestCoffeeDetailPageDriver extends TestDriver implements CoffeeDetailPageDriver {
   @override
-  String get coffeeName => '';
+  String get coffeeName => ' ';
 
   @override
-  String get coffeeDescription => '';
+  String get coffeeDescription => ' ';
 
   @override
-  String get coffeeImageUrl => '';
+  String get coffeeImageUrl => ' ';
 
   @override
   void didUpdateProvidedProperties({required int newIndex, required Coffee newCoffee}) {}

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_detail/coffee_detail_page_driver.g.dart
@@ -12,13 +12,16 @@ part of 'coffee_detail_page_driver.dart';
 
 class _$TestCoffeeDetailPageDriver extends TestDriver implements CoffeeDetailPageDriver {
   @override
-  String get coffeeName => TestCoffee.testCoffeeName;
+  String get coffeeName => '';
 
   @override
-  String get coffeeDescription => TestCoffee.testCoffeeDescription;
+  String get coffeeDescription => '';
 
   @override
-  String get coffeeImageUrl => TestCoffee.testCoffeeImageUrl;
+  String get coffeeImageUrl => '';
+
+  @override
+  void didUpdateProvidedProperties({required int newIndex, required Coffee newCoffee}) {}
 }
 
 class $CoffeeDetailPageDriverProvider extends WidgetDriverProvider<CoffeeDetailPageDriver> {

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.dart
@@ -26,10 +26,8 @@ class CoffeeLibraryPageDriver extends WidgetDriver {
     _getCoffees();
   }
 
-  @TestDriverDefaultValue(false)
   bool get isFetching => _isFetching;
 
-  @TestDriverDefaultValue(10)
   int get numberOfCoffees => _coffees.length;
 
   @TestDriverDefaultValue(TestCoffee.testCoffee)

--- a/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/coffee_library/coffee_library_page_driver.g.dart
@@ -15,12 +15,15 @@ class _$TestCoffeeLibraryPageDriver extends TestDriver implements CoffeeLibraryP
   bool get isFetching => false;
 
   @override
-  int get numberOfCoffees => 10;
+  int get numberOfCoffees => 0;
 
   @override
   Coffee getCoffeeAtIndex(int index) {
     return TestCoffee.testCoffee;
   }
+
+  @override
+  void dispose() {}
 }
 
 class $CoffeeLibraryPageDriverProvider extends WidgetDriverProvider<CoffeeLibraryPageDriver> {

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.dart
@@ -22,13 +22,10 @@ class NotLoggedInPageDriver extends WidgetDriver {
     _localization = context.read<Localization>();
   }
 
-  @TestDriverDefaultValue('Not logged in')
   String get notLoggedInText => _localization.notLoggedIn;
 
-  @TestDriverDefaultValue('Register a new account')
   String get registerNewAccountButtonText => _localization.registerNewAccount;
 
-  @TestDriverDefaultValue()
   void registerNewAccountTapped(BuildContext context) {
     _coordinator.pushMaterialPageRoute(
       context: context,

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
@@ -12,10 +12,10 @@ part of 'not_logged_in_page_driver.dart';
 
 class _$TestNotLoggedInPageDriver extends TestDriver implements NotLoggedInPageDriver {
   @override
-  String get notLoggedInText => '';
+  String get notLoggedInText => ' ';
 
   @override
-  String get registerNewAccountButtonText => '';
+  String get registerNewAccountButtonText => ' ';
 
   @override
   void didUpdateBuildContext(BuildContext context) {}

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/not_logged_in_page_driver.g.dart
@@ -12,10 +12,13 @@ part of 'not_logged_in_page_driver.dart';
 
 class _$TestNotLoggedInPageDriver extends TestDriver implements NotLoggedInPageDriver {
   @override
-  String get notLoggedInText => 'Not logged in';
+  String get notLoggedInText => '';
 
   @override
-  String get registerNewAccountButtonText => 'Register a new account';
+  String get registerNewAccountButtonText => '';
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {}
 
   @override
   void registerNewAccountTapped(BuildContext context) {}

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.dart
@@ -27,28 +27,21 @@ class RegisterAccountPageDriver extends WidgetDriver {
     _createUserService = context.read<CreateUserService>();
   }
 
-  @TestDriverDefaultValue('Register new account')
   String get pageTitle => _localization.registerNewAccount;
 
-  @TestDriverDefaultValue('Enter your desired username')
   String get usernameTextFieldPlaceholder => _localization.createUsernameInputPlaceholder;
 
-  @TestDriverDefaultValue(null)
   String? get usernameInputError => _usernameInputError;
 
-  @TestDriverDefaultValue('Register and log in')
   String get registerButtonText => _localization.registerAndLogIn;
 
-  @TestDriverDefaultValue(false)
   bool get registerIsLoading => _registerIsLoading;
 
-  @TestDriverDefaultValue()
   void usernameInputChanged(String inputName) {
     _currentUsername = inputName;
     _validateUsernameInput();
   }
 
-  @TestDriverDefaultFutureValue()
   Future<void> tappedRegister(BuildContext context) async {
     if (_createUserService.isUserValidName(_currentUsername)) {
       _setRegisterLoading(true);

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
@@ -12,16 +12,16 @@ part of 'register_account_page_driver.dart';
 
 class _$TestRegisterAccountPageDriver extends TestDriver implements RegisterAccountPageDriver {
   @override
-  String get pageTitle => '';
+  String get pageTitle => ' ';
 
   @override
-  String get usernameTextFieldPlaceholder => '';
+  String get usernameTextFieldPlaceholder => ' ';
 
   @override
-  String? get usernameInputError => '';
+  String? get usernameInputError => ' ';
 
   @override
-  String get registerButtonText => '';
+  String get registerButtonText => ' ';
 
   @override
   bool get registerIsLoading => false;

--- a/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_community/not_logged_in/register_account/register_account_page_driver.g.dart
@@ -12,19 +12,22 @@ part of 'register_account_page_driver.dart';
 
 class _$TestRegisterAccountPageDriver extends TestDriver implements RegisterAccountPageDriver {
   @override
-  String get pageTitle => 'Register new account';
+  String get pageTitle => '';
 
   @override
-  String get usernameTextFieldPlaceholder => 'Enter your desired username';
+  String get usernameTextFieldPlaceholder => '';
 
   @override
-  String? get usernameInputError => null;
+  String? get usernameInputError => '';
 
   @override
-  String get registerButtonText => 'Register and log in';
+  String get registerButtonText => '';
 
   @override
   bool get registerIsLoading => false;
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {}
 
   @override
   void usernameInputChanged(String inputName) {}

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.dart
@@ -16,9 +16,7 @@ class CoffeeCounterHeaderSectionDriver extends WidgetDriver {
     _coffeeCount = context.watch<int>();
   }
 
-  @TestDriverDefaultValue('Consumed coffees')
   String get descriptionText => _localization.consumedCoffees;
 
-  @TestDriverDefaultValue('3')
   String get amountText => '$_coffeeCount';
 }

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.g.dart
@@ -12,10 +12,10 @@ part of 'coffee_counter_header_section_driver.dart';
 
 class _$TestCoffeeCounterHeaderSectionDriver extends TestDriver implements CoffeeCounterHeaderSectionDriver {
   @override
-  String get descriptionText => '';
+  String get descriptionText => ' ';
 
   @override
-  String get amountText => '';
+  String get amountText => ' ';
 
   @override
   void didUpdateBuildContext(BuildContext context) {}

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_header_section_driver.g.dart
@@ -12,10 +12,13 @@ part of 'coffee_counter_header_section_driver.dart';
 
 class _$TestCoffeeCounterHeaderSectionDriver extends TestDriver implements CoffeeCounterHeaderSectionDriver {
   @override
-  String get descriptionText => 'Consumed coffees';
+  String get descriptionText => '';
 
   @override
-  String get amountText => '3';
+  String get amountText => '';
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {}
 }
 
 class $CoffeeCounterHeaderSectionDriverProvider extends WidgetDriverProvider<CoffeeCounterHeaderSectionDriver> {

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.dart
@@ -30,27 +30,21 @@ class CoffeeCounterWidgetDriver extends WidgetDriver {
     _localization = context.read<Localization>();
   }
 
-  @TestDriverDefaultValue(3)
   int get coffeeCount => _consumptionService.counter;
 
-  @TestDriverDefaultValue('Consume coffee quick')
   String get consumeCoffeeQuickButtonText => _localization.consumeCoffeeQuick;
 
-  @TestDriverDefaultValue('Consume coffee slow')
   String get consumeCoffeeSlowButtonText =>
       _isCurrentlyConsuming ? _localization.consumingCoffee : _localization.consumeCoffeeSlow;
 
-  @TestDriverDefaultValue('Reset consumption')
   String get resetCoffeeButtonText => _localization.resetConsumedCoffees;
 
-  @TestDriverDefaultValue()
   void consumeCoffeeQuick() {
     _consumptionService.consumedOneCoffee();
   }
 
   /// Returns true if we could consume a coffee slow.
   /// We cannot consume slow if we are already consuming a slow coffee.
-  @TestDriverDefaultFutureValue(false)
   Future<bool> consumeCoffeeSlow() async {
     if (_isCurrentlyConsuming) {
       return false;
@@ -66,7 +60,6 @@ class CoffeeCounterWidgetDriver extends WidgetDriver {
     return true;
   }
 
-  @TestDriverDefaultValue()
   void resetConsumption() {
     _consumptionService.resetConsumption();
   }

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
@@ -12,16 +12,19 @@ part of 'coffee_counter_widget_driver.dart';
 
 class _$TestCoffeeCounterWidgetDriver extends TestDriver implements CoffeeCounterWidgetDriver {
   @override
-  int get coffeeCount => 3;
+  int get coffeeCount => 0;
 
   @override
-  String get consumeCoffeeQuickButtonText => 'Consume coffee quick';
+  String get consumeCoffeeQuickButtonText => '';
 
   @override
-  String get consumeCoffeeSlowButtonText => 'Consume coffee slow';
+  String get consumeCoffeeSlowButtonText => '';
 
   @override
-  String get resetCoffeeButtonText => 'Reset consumption';
+  String get resetCoffeeButtonText => '';
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {}
 
   @override
   void consumeCoffeeQuick() {}
@@ -33,6 +36,9 @@ class _$TestCoffeeCounterWidgetDriver extends TestDriver implements CoffeeCounte
 
   @override
   void resetConsumption() {}
+
+  @override
+  void dispose() {}
 }
 
 class $CoffeeCounterWidgetDriverProvider extends WidgetDriverProvider<CoffeeCounterWidgetDriver> {

--- a/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/coffee_counter/coffee_counter_widget_driver.g.dart
@@ -15,13 +15,13 @@ class _$TestCoffeeCounterWidgetDriver extends TestDriver implements CoffeeCounte
   int get coffeeCount => 0;
 
   @override
-  String get consumeCoffeeQuickButtonText => '';
+  String get consumeCoffeeQuickButtonText => ' ';
 
   @override
-  String get consumeCoffeeSlowButtonText => '';
+  String get consumeCoffeeSlowButtonText => ' ';
 
   @override
-  String get resetCoffeeButtonText => '';
+  String get resetCoffeeButtonText => ' ';
 
   @override
   void didUpdateBuildContext(BuildContext context) {}

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.dart
@@ -22,15 +22,12 @@ class RandomCoffeeImageWidgetDriver extends WidgetDriver {
     _localization = context.read<Localization>();
   }
 
-  @TestDriverDefaultValue(TestCoffee.testCoffeeImageUrl)
   String get coffeeImageUrl {
     return _coffeeImageService.getRandomCoffeeImageUrl();
   }
 
-  @TestDriverDefaultValue('Tap image to load a new one')
   String get title => _localization.randomCoffeeImageTitle;
 
-  @TestDriverDefaultValue()
   void updateRandomImage() {
     notifyWidget();
   }

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.dart
@@ -1,4 +1,3 @@
-import 'package:example/models/coffee.dart';
 import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:widget_driver/widget_driver.dart';

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
@@ -12,10 +12,10 @@ part of 'random_coffee_image_widget_driver.dart';
 
 class _$TestRandomCoffeeImageWidgetDriver extends TestDriver implements RandomCoffeeImageWidgetDriver {
   @override
-  String get coffeeImageUrl => '';
+  String get coffeeImageUrl => ' ';
 
   @override
-  String get title => '';
+  String get title => ' ';
 
   @override
   void didUpdateBuildContext(BuildContext context) {}

--- a/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/coffee_consumption/random_coffee_image_widget/random_coffee_image_widget_driver.g.dart
@@ -12,10 +12,13 @@ part of 'random_coffee_image_widget_driver.dart';
 
 class _$TestRandomCoffeeImageWidgetDriver extends TestDriver implements RandomCoffeeImageWidgetDriver {
   @override
-  String get coffeeImageUrl => TestCoffee.testCoffeeImageUrl;
+  String get coffeeImageUrl => '';
 
   @override
-  String get title => 'Tap image to load a new one';
+  String get title => '';
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {}
 
   @override
   void updateRandomImage() {}

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
@@ -1,4 +1,3 @@
-import 'package:example/models/coffee.dart';
 import 'package:provider/provider.dart';
 import 'package:widget_driver/widget_driver.dart';
 

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.dart
@@ -1,3 +1,4 @@
+import 'package:example/models/coffee.dart';
 import 'package:provider/provider.dart';
 import 'package:widget_driver/widget_driver.dart';
 
@@ -19,14 +20,11 @@ class HomePageDriver extends WidgetDriver {
     _localization = Resolver(context).get(() => context.read<Localization>());
   }
 
-  @TestDriverDefaultValue('Coffee Demo App')
   String get title => _localization.appTitle;
 
-  @TestDriverDefaultValue(2)
   int get numberOfTabs {
     return _appTabs.tabs.length;
   }
 
-  @TestDriverDefaultValue([AppTabType.consumption, AppTabType.community])
   List<AppTabType> get appTabs => _appTabs.tabs;
 }

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
@@ -12,13 +12,16 @@ part of 'home_page_driver.dart';
 
 class _$TestHomePageDriver extends TestDriver implements HomePageDriver {
   @override
-  String get title => 'Coffee Demo App';
+  String get title => '';
 
   @override
-  int get numberOfTabs => 2;
+  int get numberOfTabs => 0;
 
   @override
-  List<AppTabType> get appTabs => [AppTabType.consumption, AppTabType.community];
+  List<AppTabType> get appTabs => [];
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {}
 }
 
 class $HomePageDriverProvider extends WidgetDriverProvider<HomePageDriver> {

--- a/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/home_page_driver.g.dart
@@ -12,7 +12,7 @@ part of 'home_page_driver.dart';
 
 class _$TestHomePageDriver extends TestDriver implements HomePageDriver {
   @override
-  String get title => '';
+  String get title => ' ';
 
   @override
   int get numberOfTabs => 0;

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.dart
@@ -23,12 +23,10 @@ class LogInOutButtonDriver extends WidgetDriver {
     });
   }
 
-  @TestDriverDefaultValue('Log in')
   String get buttonText {
     return _authService.isLoggedIn ? _localization.logOut : _localization.logIn;
   }
 
-  @TestDriverDefaultValue()
   void toggleLogInOut() {
     if (_authService.isLoggedIn) {
       _authService.logOut();

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
@@ -12,7 +12,7 @@ part of 'log_in_out_button_driver.dart';
 
 class _$TestLogInOutButtonDriver extends TestDriver implements LogInOutButtonDriver {
   @override
-  String get buttonText => '';
+  String get buttonText => ' ';
 
   @override
   void didUpdateBuildContext(BuildContext context) {}

--- a/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
+++ b/widget_driver/example/lib/widgets/home_page/log_in_out_button/log_in_out_button_driver.g.dart
@@ -12,10 +12,16 @@ part of 'log_in_out_button_driver.dart';
 
 class _$TestLogInOutButtonDriver extends TestDriver implements LogInOutButtonDriver {
   @override
-  String get buttonText => 'Log in';
+  String get buttonText => '';
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {}
 
   @override
   void toggleLogInOut() {}
+
+  @override
+  void dispose() {}
 }
 
 class $LogInOutButtonDriverProvider extends WidgetDriverProvider<LogInOutButtonDriver> {

--- a/widget_driver/example/lib/widgets/my_app_driver.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.dart
@@ -15,6 +15,5 @@ class MyAppDriver extends WidgetDriver {
     _localization = Resolver(context).get(() => context.read<Localization>());
   }
 
-  @TestDriverDefaultValue('Coffee Demo App')
   String get appTitle => _localization.appTitle;
 }

--- a/widget_driver/example/lib/widgets/my_app_driver.g.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.g.dart
@@ -12,7 +12,7 @@ part of 'my_app_driver.dart';
 
 class _$TestMyAppDriver extends TestDriver implements MyAppDriver {
   @override
-  String get appTitle => '';
+  String get appTitle => ' ';
 
   @override
   void didUpdateBuildContext(BuildContext context) {}

--- a/widget_driver/example/lib/widgets/my_app_driver.g.dart
+++ b/widget_driver/example/lib/widgets/my_app_driver.g.dart
@@ -12,7 +12,10 @@ part of 'my_app_driver.dart';
 
 class _$TestMyAppDriver extends TestDriver implements MyAppDriver {
   @override
-  String get appTitle => 'Coffee Demo App';
+  String get appTitle => '';
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {}
 }
 
 class $MyAppDriverProvider extends WidgetDriverProvider<MyAppDriver> {

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.dart
@@ -4,6 +4,5 @@ part 'playground_test_child_widget_driver.g.dart';
 
 @GenerateTestDriver()
 class PlaygroundTestChildWidgetDriver extends WidgetDriver {
-  @TestDriverDefaultValue('Text coming from TestDriver')
   String get theText => 'Text coming from RealDriver';
 }

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.g.dart
@@ -12,7 +12,7 @@ part of 'playground_test_child_widget_driver.dart';
 
 class _$TestPlaygroundTestChildWidgetDriver extends TestDriver implements PlaygroundTestChildWidgetDriver {
   @override
-  String get theText => '';
+  String get theText => ' ';
 }
 
 class $PlaygroundTestChildWidgetDriverProvider extends WidgetDriverProvider<PlaygroundTestChildWidgetDriver> {

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_child_widget_driver.g.dart
@@ -12,7 +12,7 @@ part of 'playground_test_child_widget_driver.dart';
 
 class _$TestPlaygroundTestChildWidgetDriver extends TestDriver implements PlaygroundTestChildWidgetDriver {
   @override
-  String get theText => 'Text coming from TestDriver';
+  String get theText => '';
 }
 
 class $PlaygroundTestChildWidgetDriverProvider extends WidgetDriverProvider<PlaygroundTestChildWidgetDriver> {

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.dart
@@ -4,6 +4,5 @@ part 'playground_test_widget_driver.g.dart';
 
 @GenerateTestDriver()
 class PlaygroundTestWidgetDriver extends WidgetDriver {
-  @TestDriverDefaultValue('Button header text from TestDriver')
   String get buttonHeaderText => 'Button header text from RealDriver';
 }

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.g.dart
@@ -12,7 +12,7 @@ part of 'playground_test_widget_driver.dart';
 
 class _$TestPlaygroundTestWidgetDriver extends TestDriver implements PlaygroundTestWidgetDriver {
   @override
-  String get buttonHeaderText => '';
+  String get buttonHeaderText => ' ';
 }
 
 class $PlaygroundTestWidgetDriverProvider extends WidgetDriverProvider<PlaygroundTestWidgetDriver> {

--- a/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.g.dart
+++ b/widget_driver/example/lib/widgets/playground/playground_test_widget/playground_test_widget_driver.g.dart
@@ -12,7 +12,7 @@ part of 'playground_test_widget_driver.dart';
 
 class _$TestPlaygroundTestWidgetDriver extends TestDriver implements PlaygroundTestWidgetDriver {
   @override
-  String get buttonHeaderText => 'Button header text from TestDriver';
+  String get buttonHeaderText => '';
 }
 
 class $PlaygroundTestWidgetDriverProvider extends WidgetDriverProvider<PlaygroundTestWidgetDriver> {

--- a/widget_driver_generator/CHANGELOG.md
+++ b/widget_driver_generator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.1.0
+
+* Introduces predefined default values for frequently used types to minimize the need of annotations.
+* Fixes a bug that allows the generation of setters.
+
 ## 1.0.3
 
 * Updates images in readme to look more "snappy" 😁

--- a/widget_driver_generator/README.md
+++ b/widget_driver_generator/README.md
@@ -52,11 +52,11 @@ class MyDriver extends WidgetDriver {
 }
 ```
 
-Now there is just one thing missing. You need to annotate all public properties and methods in your `Driver` that you want to be able to use in your widgets later.
+Now there is just one step missing. Any public properties and methods in your `Driver` can be annotated so they provide a specific value in tests. Simple return types like all of [Dart's built-in types](https://dart.dev/language/built-in-types), enums, Optionals and some frequently used types in widgets like `Color`, `IconData` and `FontWeight` are already covered. More complex type, like your custom classes, must be covered in your code.
 
-Annotate the properties with `TestDriverDefaultValue({default_value})`. As a parameter to the `TestDriverDefaultValue` you pass in the default value which you want the driver to give to the widget when the widget is being tested.
+Annotate the properties you want to explicitly define in the `TestDriver` with `TestDriverDefaultValue({default_value})`. As a parameter to the `TestDriverDefaultValue` you pass in the default value which you want the driver to give to the widget when the widget is being tested.
 
-You also annotate your methods with `TestDriverDefaultValue({default_return_value})`. As a parameter to the `TestDriverDefaultValue` you pass in the default value which you want the driver to return to the widget when the widget calls this method during tests. If the method does not return anything, then just pass nothing as a parameter.
+You can also annotate your methods with `TestDriverDefaultValue({default_return_value})`. As a parameter to the `TestDriverDefaultValue` you pass in the default value which you want the driver to return to the widget when the widget calls this method during tests. If the method does not return anything, then just pass nothing as a parameter.
 If you method returns a future, then you can use the `TestDriverDefaultFutureValue` annotation instead. It will correctly generate a future with the return value you pass into it.
 
 ```dart
@@ -64,22 +64,26 @@ If you method returns a future, then you can use the `TestDriverDefaultFutureVal
 class MyDriver extends WidgetDriver {
   ...
 
-  @TestDriverDefaultValue(1)
   int get value => _someService.value;
 
-  @TestDriverDefaultValue()
+  @TestDriverDefaultValue(CustomClass())
+  CustomClass get value => _counterService.getCustomClass;
+
   void doSomething() {
     ...
   }
 
-  @TestDriverDefaultValue('The string')
   String giveMeSomeString() {
     return _someService.getSomeString();
   }
 
-  @TestDriverDefaultFutureValue(123)
   Future<int> giveMeSomeIntSoon() {
     return _someService.getSomeIntSoon();
+  }
+
+  @TestDriverDefaultFutureValue(CustomClass())
+  Future<CustomClass> giveMeSomeCustomClassSoon() {
+  return _someService.getSomeCustomClassSoon();
   }
 }
 ```

--- a/widget_driver_generator/lib/src/code_providers/test_driver_code_provider.dart
+++ b/widget_driver_generator/lib/src/code_providers/test_driver_code_provider.dart
@@ -4,18 +4,21 @@ import '../models/annotated_element.dart';
 
 class TestDriverCodeProvider {
   final List<AnnotatedElement> _methods;
-  final List<AnnotatedElement> _properties;
+  final List<AnnotatedElement> _getProperties;
+  final List<AnnotatedElement> _setProperties;
   final List<AnnotatedElement> _fields;
   final String _driverClassName;
   final String _testDriverClassName;
 
   TestDriverCodeProvider({
     required List<AnnotatedElement> methods,
-    required List<AnnotatedElement> properties,
+    required List<AnnotatedElement> getProperties,
+    required List<AnnotatedElement> setProperties,
     required List<AnnotatedElement> fields,
     required String driverClassName,
   })  : _methods = methods,
-        _properties = properties,
+        _getProperties = getProperties,
+        _setProperties = setProperties,
         _fields = fields,
         _driverClassName = driverClassName,
         _testDriverClassName = ClassUtils.testDriverClassName(driverClassName);
@@ -41,9 +44,15 @@ class $_testDriverClassName extends TestDriver implements $_driverClassName {
 }
 ''';
 
-  /// Joins `_getComputedPropertyCode()` for every property in `_properties`.
-  String _propertyCode() =>
-      _properties.map((e) => _getComputedPropertyCode(e.codeDefinition, e.returnValue)).join(doubleEmptyLine);
+  /// Joins `_getComputedPropertyCode()` for every property in `_getProperties` and in `_setProperties`.
+  String _propertyCode() {
+    final List<String> properties = [];
+    final getProperties = _getProperties.map((e) => _getComputedPropertyCode(e.codeDefinition, e.returnValue));
+    properties.addAll(getProperties);
+    final setProperties = _setProperties.map((e) => _getMethodCode(e.codeDefinition, e.returnValue));
+    properties.addAll(setProperties);
+    return properties.join(doubleEmptyLine);
+  }
 
   /// Joins `_getMethodCode()` for every method in `_methods`.
   String _methodsCode() => _methods.map((e) => _getMethodCode(e.codeDefinition, e.returnValue)).join(doubleEmptyLine);

--- a/widget_driver_generator/lib/src/model_visitor.dart
+++ b/widget_driver_generator/lib/src/model_visitor.dart
@@ -5,8 +5,8 @@ import 'package:widget_driver_annotation/widget_driver_annotation.dart';
 import 'models/annotated_element.dart';
 import 'models/providable_field.dart';
 import 'utils/element_utils.dart';
-import 'utils/property_accessor_element_extensions.dart';
 import 'utils/field_element_extensions.dart';
+import 'utils/property_accessor_element_extensions.dart';
 
 typedef CodeGeneratorMethod = String Function(String codeDefinition, String returnValue);
 
@@ -55,7 +55,7 @@ class ModelVisitor extends SimpleElementVisitor<void> {
       element: element,
       validAnnotationTypes: _validAnnotationTypes,
     );
-    if (!element.name.startsWith('_')) {
+    if (element.isPublic) {
       final type = element.type;
       fields.add(AnnotatedElement.fromElement(_elementUtils, element, validAnnotationType, type));
     }
@@ -70,7 +70,7 @@ class ModelVisitor extends SimpleElementVisitor<void> {
       element: element,
       validAnnotationTypes: _validAnnotationTypes,
     );
-    if (!element.name.startsWith('_')) {
+    if (element.isPublic) {
       final returnType = element.returnType;
       final property = AnnotatedElement.fromElement(_elementUtils, element, validAnnotationType, returnType);
       if (element.isSetter) {
@@ -87,7 +87,7 @@ class ModelVisitor extends SimpleElementVisitor<void> {
       element: element,
       validAnnotationTypes: _validAnnotationTypes,
     );
-    if (!element.name.startsWith('_')) {
+    if (element.isPublic) {
       final returnType = element.returnType;
       methods.add(AnnotatedElement.fromElement(_elementUtils, element, validAnnotationType, returnType));
     }

--- a/widget_driver_generator/lib/src/model_visitor.dart
+++ b/widget_driver_generator/lib/src/model_visitor.dart
@@ -5,6 +5,8 @@ import 'package:widget_driver_annotation/widget_driver_annotation.dart';
 import 'models/annotated_element.dart';
 import 'models/providable_field.dart';
 import 'utils/element_utils.dart';
+import 'utils/property_accessor_element_extensions.dart';
+import 'utils/field_element_extensions.dart';
 
 typedef CodeGeneratorMethod = String Function(String codeDefinition, String returnValue);
 
@@ -13,7 +15,8 @@ class ModelVisitor extends SimpleElementVisitor<void> {
   String className = "";
   final fields = <AnnotatedElement>[];
   final methods = <AnnotatedElement>[];
-  final properties = <AnnotatedElement>[];
+  final getProperties = <AnnotatedElement>[];
+  final setProperties = <AnnotatedElement>[];
   final providableFields = <ProvidableField>[];
   final ElementUtils _elementUtils;
 
@@ -45,23 +48,36 @@ class ModelVisitor extends SimpleElementVisitor<void> {
 
   @override
   void visitFieldElement(FieldElement element) {
+    if (element.isRedundantToPropertyAccessorElement) {
+      return;
+    }
     final validAnnotationType = _elementUtils.getValidAnnotation(
       element: element,
       validAnnotationTypes: _validAnnotationTypes,
     );
-    if (validAnnotationType != null) {
-      fields.add(AnnotatedElement.fromElement(_elementUtils, element, validAnnotationType));
+    if (!element.name.startsWith('_')) {
+      final type = element.type;
+      fields.add(AnnotatedElement.fromElement(_elementUtils, element, validAnnotationType, type));
     }
   }
 
   @override
   void visitPropertyAccessorElement(PropertyAccessorElement element) {
+    if (element.isRedundantToFieldElement) {
+      return;
+    }
     final validAnnotationType = _elementUtils.getValidAnnotation(
       element: element,
       validAnnotationTypes: _validAnnotationTypes,
     );
-    if (validAnnotationType != null) {
-      properties.add(AnnotatedElement.fromElement(_elementUtils, element, validAnnotationType));
+    if (!element.name.startsWith('_')) {
+      final returnType = element.returnType;
+      final property = AnnotatedElement.fromElement(_elementUtils, element, validAnnotationType, returnType);
+      if (element.isSetter) {
+        setProperties.add(property);
+      } else {
+        getProperties.add(property);
+      }
     }
   }
 
@@ -71,8 +87,9 @@ class ModelVisitor extends SimpleElementVisitor<void> {
       element: element,
       validAnnotationTypes: _validAnnotationTypes,
     );
-    if (validAnnotationType != null) {
-      methods.add(AnnotatedElement.fromElement(_elementUtils, element, validAnnotationType));
+    if (!element.name.startsWith('_')) {
+      final returnType = element.returnType;
+      methods.add(AnnotatedElement.fromElement(_elementUtils, element, validAnnotationType, returnType));
     }
   }
 }

--- a/widget_driver_generator/lib/src/models/annotated_element.dart
+++ b/widget_driver_generator/lib/src/models/annotated_element.dart
@@ -33,7 +33,7 @@ class AnnotatedElement {
     } else {
       throw Exception("""
 ${elementType.toString()} has no default test value. 
-You need to annotate \"$codeDefinition\" with a default value:
+You need to annotate "$codeDefinition" with a default value:
 ...
   @TestDriverDefaultValue(Instance of ${elementType.toString()})
   $codeDefinition

--- a/widget_driver_generator/lib/src/models/annotated_element.dart
+++ b/widget_driver_generator/lib/src/models/annotated_element.dart
@@ -1,5 +1,8 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:widget_driver_generator/src/utils/element_utils.dart';
+
+import '../utils/default_return_value_helper.dart';
 
 /// Class representing fields, properties and methods that have been annotated with either `TestDriverDefaultValue` or
 /// `TestDriverDefaultFutureValue`, to keep track of the [returnValue] and [codeDefinition].
@@ -16,9 +19,26 @@ class AnnotatedElement {
     ElementUtils elementUtils,
     Element element,
     dynamic validAnnotationType,
+    DartType elementType,
   ) {
-    final returnValue = elementUtils.getReturnValue(element: element, annotationType: validAnnotationType);
     final codeDefinition = elementUtils.getCodeDefinitionForElement(element);
-    return AnnotatedElement(returnValue: returnValue, codeDefinition: codeDefinition);
+    if (validAnnotationType == null && DefaultReturnValueHelper.hasDefaultValueForType(elementType)) {
+      return AnnotatedElement(
+        returnValue: DefaultReturnValueHelper.getDefaultValueFor(elementType),
+        codeDefinition: codeDefinition,
+      );
+    } else if (validAnnotationType != null) {
+      final returnValue = elementUtils.getReturnValue(element: element, annotationType: validAnnotationType);
+      return AnnotatedElement(returnValue: returnValue, codeDefinition: codeDefinition);
+    } else {
+      throw Exception("""
+${elementType.toString()} has no default test value. 
+You need to annotate \"$codeDefinition\" with a default value:
+...
+  @TestDriverDefaultValue(Instance of ${elementType.toString()})
+  $codeDefinition
+...
+      """);
+    }
   }
 }

--- a/widget_driver_generator/lib/src/utils/default_return_value_helper.dart
+++ b/widget_driver_generator/lib/src/utils/default_return_value_helper.dart
@@ -34,7 +34,7 @@ class DefaultReturnValueHelper {
     }
     var typeName = type.toString();
     if (type is InterfaceType && type.element is ClassElement && type.element.name == "Future") {
-      typeName = type.typeArguments.first.toString();
+      return hasDefaultValueForType(type.typeArguments.first);
     }
     return _hasDefaultValueForTypeName(typeName);
   }
@@ -44,7 +44,7 @@ class DefaultReturnValueHelper {
   static final Map<String, String> _defaultTypeValueMap = {
     "int": "0",
     "double": "0.0",
-    "String": "''",
+    "String": "' '",
     "bool": "false",
     "List": "[]",
     "Set": "{}",

--- a/widget_driver_generator/lib/src/utils/default_return_value_helper.dart
+++ b/widget_driver_generator/lib/src/utils/default_return_value_helper.dart
@@ -1,0 +1,107 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+/// Class that provides logic to determine default return values.
+class DefaultReturnValueHelper {
+  /// Return the default value written as code inside a String for the passed in [type].
+  /// It is important to call [hasDefaultValueForType] first to make sure a default value exists.
+  /// Otherwise the code generation might generate faulty code.
+  static String getDefaultValueFor(DartType type) {
+    if (type.element is EnumElement) {
+      // We can safely take the first enum value since dart enforces for enums to have at least one value.
+      return "${_getSanitizedTypeName(type.toString())}.values[0]";
+    }
+    if (type is RecordType) {
+      return _getDefaultValueForRecord(type);
+    }
+    if (type is InterfaceType && type.element is ClassElement && type.element.name == "Future") {
+      final defaultValue = getDefaultValueFor(type.typeArguments.first);
+      return "Future.value($defaultValue)";
+    } else {
+      return _getDefaultValueForTypeName(type.toString());
+    }
+  }
+
+  /// Returns `true` if a default value exists for the passed in [type].
+  /// If it returns `false`, [getDefaultValueFor] might not return a proper value and should not be used.
+  static bool hasDefaultValueForType(DartType type) {
+    if (type.element is EnumElement) {
+      return true;
+    }
+    // RecordTypes are tuples (value1, value2) that were introduced with dart 3.0 and are a edge case here
+    if (type is RecordType) {
+      return _hasDefaultValueForRecord(type);
+    }
+    var typeName = type.toString();
+    if (type is InterfaceType && type.element is ClassElement && type.element.name == "Future") {
+      typeName = type.typeArguments.first.toString();
+    }
+    return _hasDefaultValueForTypeName(typeName);
+  }
+
+  // to introduce more types with default values, add them to this map.
+  // All enum values and optional values are already covered and don't have to be put in here.
+  static final Map<String, String> _defaultTypeValueMap = {
+    "int": "0",
+    "double": "0.0",
+    "String": "''",
+    "bool": "false",
+    "List": "[]",
+    "Set": "{}",
+    "Map": "{}",
+    "Symbol": "const Symbol(\"foo\")",
+    "void": "",
+    "Color": "Colors.black",
+    "IconData": "const IconData(0)",
+    "FontWeight": "FontWeight.normal",
+  };
+
+  static bool _hasDefaultValueForTypeName(String typeName) {
+    // For all optionals we can return null as a value no matter if it's in the list or not.
+    if (_isOptional(typeName)) {
+      return true;
+    }
+    return _defaultTypeValueMap.containsKey(_getSanitizedTypeName(typeName));
+  }
+
+  static String _getDefaultValueForTypeName(String typeName) {
+    final defaultValue = _defaultTypeValueMap[_getSanitizedTypeName(typeName)];
+    // For all unknown optionals we can return null as a value
+    if (defaultValue == null && _isOptional(typeName)) {
+      return "null";
+    } else {
+      return defaultValue ?? '';
+    }
+  }
+
+  static String _getSanitizedTypeName(String name) {
+    var typeName = name;
+    // This way we can give a one for all default value for Lists, Sets and Maps
+    if (_isListSetOrMap(typeName)) {
+      typeName = typeName.substring(0, typeName.indexOf('<'));
+    }
+    // All optionals get the default value of the type if it exists
+    if (_isOptional(typeName)) {
+      typeName = typeName.substring(0, typeName.indexOf('?'));
+    }
+    return typeName;
+  }
+
+  static bool _isListSetOrMap(String typeName) => typeName.contains('<');
+
+  static bool _isOptional(String typeName) => typeName.contains('?');
+
+  static bool _hasDefaultValueForRecord(RecordType recordType) {
+    var hasValue = true;
+    for (final fieldType in recordType.positionalFields) {
+      hasValue = hasValue && hasDefaultValueForType(fieldType.type);
+    }
+    return hasValue;
+  }
+
+  static String _getDefaultValueForRecord(RecordType recordType) {
+    final firstValue = getDefaultValueFor(recordType.positionalFields[0].type);
+    final secondValue = getDefaultValueFor(recordType.positionalFields[1].type);
+    return "($firstValue, $secondValue)";
+  }
+}

--- a/widget_driver_generator/lib/src/utils/default_return_value_helper.dart
+++ b/widget_driver_generator/lib/src/utils/default_return_value_helper.dart
@@ -53,7 +53,6 @@ class DefaultReturnValueHelper {
     "void": "",
     "Color": "Colors.black",
     "IconData": "const IconData(0)",
-    "FontWeight": "FontWeight.normal",
   };
 
   static bool _hasDefaultValueForTypeName(String typeName) {

--- a/widget_driver_generator/lib/src/utils/field_element_extensions.dart
+++ b/widget_driver_generator/lib/src/utils/field_element_extensions.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
+// ignore: implementation_imports
 import 'package:analyzer/src/dart/element/element.dart';
 
 extension FieldElementExtension on FieldElement {

--- a/widget_driver_generator/lib/src/utils/field_element_extensions.dart
+++ b/widget_driver_generator/lib/src/utils/field_element_extensions.dart
@@ -1,0 +1,8 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/element/element.dart';
+
+extension FieldElementExtension on FieldElement {
+  /// All getters are also treated as fields but have explicit getters.
+  bool get isRedundantToPropertyAccessorElement =>
+      setter is! PropertyAccessorElementImpl_ImplicitSetter && getter is! PropertyAccessorElementImpl_ImplicitGetter;
+}

--- a/widget_driver_generator/lib/src/utils/property_accessor_element_extensions.dart
+++ b/widget_driver_generator/lib/src/utils/property_accessor_element_extensions.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+// ignore: implementation_imports
 import 'package:analyzer/src/dart/element/element.dart';
 
 extension PropertyAccessorElementExtension on PropertyAccessorElement {

--- a/widget_driver_generator/lib/src/utils/property_accessor_element_extensions.dart
+++ b/widget_driver_generator/lib/src/utils/property_accessor_element_extensions.dart
@@ -1,0 +1,12 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/src/dart/element/element.dart';
+
+extension PropertyAccessorElementExtension on PropertyAccessorElement {
+  /// All fields have implicit getters and setters.
+  bool get isRedundantToFieldElement =>
+      this is PropertyAccessorElementImpl_ImplicitSetter || this is PropertyAccessorElementImpl_ImplicitGetter;
+
+  /// VoidType PropertyAccessorElements are setters.
+  bool get isSetter => returnType is VoidType;
+}

--- a/widget_driver_generator/lib/src/widget_driver_generator.dart
+++ b/widget_driver_generator/lib/src/widget_driver_generator.dart
@@ -42,7 +42,8 @@ class WidgetDriverGenerator extends GeneratorForAnnotation<GenerateTestDriver> {
 
     final testDriverCodeProvider = TestDriverCodeProvider(
       methods: visitor.methods,
-      properties: visitor.properties,
+      getProperties: visitor.getProperties,
+      setProperties: visitor.setProperties,
       fields: visitor.fields,
       driverClassName: driverClassName,
     );

--- a/widget_driver_generator/pubspec.yaml
+++ b/widget_driver_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_generator
 description: This package provides generators for WidgetDriver to automate the creation of your TestDrivers and WidgetDriverProviders
-version: 1.0.3
+version: 1.1.0
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_generator
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 

--- a/widget_driver_generator/test/code_providers/test_driver_code_provider_test.dart
+++ b/widget_driver_generator/test/code_providers/test_driver_code_provider_test.dart
@@ -7,7 +7,8 @@ void main() {
     test('Builds with no elements', () {
       final codeProvider = TestDriverCodeProvider(
         methods: [],
-        properties: [],
+        getProperties: [],
+        setProperties: [],
         fields: [],
         driverClassName: 'ExampleDriver',
       );
@@ -26,7 +27,8 @@ class _\$TestExampleDriver extends TestDriver implements ExampleDriver {
     test('Builds with one field', () {
       final codeProvider = TestDriverCodeProvider(
         methods: [],
-        properties: [],
+        getProperties: [],
+        setProperties: [],
         fields: [
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'final String example'),
         ],
@@ -48,7 +50,8 @@ final String example = '';
     test('Builds with multiple fields', () {
       final codeProvider = TestDriverCodeProvider(
         methods: [],
-        properties: [],
+        getProperties: [],
+        setProperties: [],
         fields: [
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'final String example'),
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'final String example2'),
@@ -71,12 +74,13 @@ final String example2 = '';
       expect(codeProvider.code, expected);
     });
 
-    test("Builds with one property", () {
+    test("Builds with one getProperty", () {
       final codeProvider = TestDriverCodeProvider(
         methods: [],
-        properties: [
+        getProperties: [
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'String get example'),
         ],
+        setProperties: [],
         fields: [],
         driverClassName: 'ExampleDriver',
       );
@@ -93,13 +97,14 @@ String get example => '';
       expect(codeProvider.code, expected);
     });
 
-    test("Builds with multiple properties", () {
+    test("Builds with multiple getProperties", () {
       final codeProvider = TestDriverCodeProvider(
         methods: [],
-        properties: [
+        getProperties: [
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'String get example'),
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'String get example2'),
         ],
+        setProperties: [],
         fields: [],
         driverClassName: 'ExampleDriver',
       );
@@ -119,12 +124,63 @@ String get example2 => '';
       expect(codeProvider.code, expected);
     });
 
+    test("Builds with one setProperty", () {
+      final codeProvider = TestDriverCodeProvider(
+        methods: [],
+        getProperties: [],
+        setProperties: [
+          const AnnotatedElement(returnValue: '', codeDefinition: 'void set example(String newExample)'),
+        ],
+        fields: [],
+        driverClassName: 'ExampleDriver',
+      );
+      const expected = '''
+class _\$TestExampleDriver extends TestDriver implements ExampleDriver {
+  
+
+  @override
+void set example(String newExample) {}
+
+  
+}
+''';
+      expect(codeProvider.code, expected);
+    });
+
+    test("Builds with multiple setProperties", () {
+      final codeProvider = TestDriverCodeProvider(
+        methods: [],
+        getProperties: [],
+        setProperties: [
+          const AnnotatedElement(returnValue: '', codeDefinition: 'void set example(String newExample)'),
+          const AnnotatedElement(returnValue: '', codeDefinition: 'void set example2(String newExample2)'),
+        ],
+        fields: [],
+        driverClassName: 'ExampleDriver',
+      );
+      const expected = '''
+class _\$TestExampleDriver extends TestDriver implements ExampleDriver {
+  
+
+  @override
+void set example(String newExample) {}
+
+@override
+void set example2(String newExample2) {}
+
+  
+}
+''';
+      expect(codeProvider.code, expected);
+    });
+
     test('Builds with one method', () {
       final codeProvider = TestDriverCodeProvider(
         methods: [
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'String example()'),
         ],
-        properties: [],
+        getProperties: [],
+        setProperties: [],
         fields: [],
         driverClassName: 'ExampleDriver',
       );
@@ -149,7 +205,8 @@ String example() {
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'String example()'),
           const AnnotatedElement(returnValue: '', codeDefinition: 'void example2()'),
         ],
-        properties: [],
+        getProperties: [],
+        setProperties: [],
         fields: [],
         driverClassName: 'ExampleDriver',
       );
@@ -177,9 +234,13 @@ void example2() {}
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'String example()'),
           const AnnotatedElement(returnValue: '', codeDefinition: 'void example2()'),
         ],
-        properties: [
+        getProperties: [
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'String get example'),
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'String get example2'),
+        ],
+        setProperties: [
+          const AnnotatedElement(returnValue: '', codeDefinition: 'void set example(String newExample)'),
+          const AnnotatedElement(returnValue: '', codeDefinition: 'void set example2(String newExample2)'),
         ],
         fields: [
           const AnnotatedElement(returnValue: '\'\'', codeDefinition: 'final String example'),
@@ -200,6 +261,12 @@ String get example => '';
 
 @override
 String get example2 => '';
+
+@override
+void set example(String newExample) {}
+
+@override
+void set example2(String newExample2) {}
 
   @override
 String example() {

--- a/widget_driver_generator/test/utils/field_element_extensions_test.dart
+++ b/widget_driver_generator/test/utils/field_element_extensions_test.dart
@@ -1,0 +1,35 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/element/element.dart';
+import 'package:test/test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:widget_driver_generator/src/utils/field_element_extensions.dart';
+
+class MockFieldElement extends Mock implements FieldElement {}
+
+class MockPropertyAccessorElementImplImplicitSetter extends Mock
+    implements PropertyAccessorElementImpl_ImplicitSetter {}
+
+class MockPropertyAccessorElementImplImplicitGetter extends Mock
+    implements PropertyAccessorElementImpl_ImplicitGetter {}
+
+void main() {
+  group('FieldElementExtension: isRedundantToPropertyAccessorElement', () {
+    test('returns false for a FieldElement with implicit setter and getter (aka variable field)', () {
+      final sut = MockFieldElement();
+      when(() => sut.setter).thenReturn(MockPropertyAccessorElementImplImplicitSetter());
+      when(() => sut.getter).thenReturn(MockPropertyAccessorElementImplImplicitGetter());
+      expect(sut.isRedundantToPropertyAccessorElement, isFalse);
+    });
+
+    test('returns false for a FieldElement with implicit getter (aka final field)', () {
+      final sut = MockFieldElement();
+      when(() => sut.getter).thenReturn(MockPropertyAccessorElementImplImplicitGetter());
+      expect(sut.isRedundantToPropertyAccessorElement, isFalse);
+    });
+
+    test('returns true for a FieldElement with neither implicit setter nor getter (aka property)', () {
+      final sut = MockFieldElement();
+      expect(sut.isRedundantToPropertyAccessorElement, isTrue);
+    });
+  });
+}

--- a/widget_driver_generator/test/utils/property_accessor_element_extensions_test.dart
+++ b/widget_driver_generator/test/utils/property_accessor_element_extensions_test.dart
@@ -1,0 +1,34 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/element/element.dart';
+import 'package:test/test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:widget_driver_generator/src/utils/property_accessor_element_extensions.dart';
+
+class MockPropertyAccessorElement extends Mock implements PropertyAccessorElement {}
+
+class MockPropertyAccessorElementImplImplicitSetter extends Mock
+    implements PropertyAccessorElementImpl_ImplicitSetter {}
+
+class MockPropertyAccessorElementImplImplicitGetter extends Mock
+    implements PropertyAccessorElementImpl_ImplicitGetter {}
+
+void main() {
+  group('PropertyAccessorElementExtension:', () {
+    group('isRedundantToFieldElement:', () {
+      test('returns false for a PropertyAccessorElementImpl_ImplicitSetter', () {
+        final sut = MockPropertyAccessorElementImplImplicitSetter();
+        expect(sut.isRedundantToFieldElement, isTrue);
+      });
+
+      test('returns false for a PropertyAccessorElementImpl_ImplicitGetter', () {
+        final sut = MockPropertyAccessorElementImplImplicitGetter();
+        expect(sut.isRedundantToFieldElement, isTrue);
+      });
+
+      test('returns false for a PropertyAccessorElement', () {
+        final sut = MockPropertyAccessorElement();
+        expect(sut.isRedundantToFieldElement, isFalse);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description
This is the implementation for [issue 155](https://github.com/bmw-tech/widget_driver/issues/155). It provides the following default values for the respective types:

    int: 0,
    double: 0.0,
    String: '',
    bool: false,
    List: [],
    Set: {},
    Map: {},
    Symbol: const Symbol("foo"),
    void: ,
    Color: Colors.black,
    IconData: const IconData(0),

also: Futures return Future.value(defaultValue of type) any enums will always be set to the first enum value and any Optionals, that are not of the above mentioned types, are returning "null"

Also this solves a bug we have in the current code:
setters were not generated properly since they were generated like getters which is not appropriate. They need to be generated similar to methods.

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [x] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [x] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
