### PR TITLE
introduce lineLength option for generator

### DIFF
--- a/widget_driver/example/build.yaml
+++ b/widget_driver/example/build.yaml
@@ -9,3 +9,4 @@ targets:
             "int": "123"
             "Coffee": "const Coffee(name: 'Coffee', description: 'Some desc', imageUrl: 'http://www.exampleImage.com/image',)"
             "String": "'Hello World'"
+          lineLength: 120

--- a/widget_driver_generator/CHANGELOG.md
+++ b/widget_driver_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.0
+
+* Introduces the option to specify formatter line length in build.yaml.
+
 ## 1.2.0
 
 * Introduces the option to specify default values for types in your build.yaml.

--- a/widget_driver_generator/lib/builder.dart
+++ b/widget_driver_generator/lib/builder.dart
@@ -1,10 +1,20 @@
 library widget_driver_generator;
 
 import 'package:build/build.dart';
+import 'package:dart_style/dart_style.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'src/widget_driver_generator.dart';
 
 /// source_gen helper function, which calls WidgetDriverGenerator to generate TestDrivers and WidgetDriverProviders
-Builder generateWidgetDriver(BuilderOptions options) =>
-    SharedPartBuilder([WidgetDriverGenerator(options: options)], 'widget_driver_generator');
+Builder generateWidgetDriver(BuilderOptions options) {
+  final customLineLength = options.config['lineLength'];
+  if (customLineLength != null && customLineLength is! int) {
+    throw Exception("lineLength specified in build.yaml that is not of type int");
+  }
+  return SharedPartBuilder(
+    [WidgetDriverGenerator(options: options)],
+    'widget_driver_generator',
+    formatOutput: DartFormatter(pageWidth: customLineLength).format,
+  );
+}

--- a/widget_driver_generator/pubspec.yaml
+++ b/widget_driver_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_generator
 description: This package provides generators for WidgetDriver to automate the creation of your TestDrivers and WidgetDriverProviders
-version: 1.2.0
+version: 1.3.0
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_generator
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 
@@ -18,6 +18,7 @@ dependencies:
   analyzer: ^5.13.0
   widget_driver_annotation: ^1.0.2
   yaml: ^3.1.2
+  dart_style: ^2.3.2
 
 dev_dependencies:
   build_runner: ^2.0.0


### PR DESCRIPTION
<!--
  Wohoo! 🥳 Thanks for contributing! The coding part is Done. Now lets get some reviews!
  Please provide a description and fill in the checklist to ensure that your PR can be accepted quickly.
-->

## Description
This introduces the option to add "lineLength" to the build.yaml. This will generate the widgetDriver code with the desired line length. It will however not affect the code of other build_runner plugins.

Note that the dart team considers the feature we use as "unoffical" and used for testing. See [this](https://github.com/dart-lang/source_gen/issues/424) as a reference.

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
