### PR TITLE
[166] Generated optional fields have unnecessary null initialization

### DIFF
--- a/widget_driver_generator/CHANGELOG.md
+++ b/widget_driver_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.3
+
+* Introduces the option to specify formatter line length in build.yaml.
+
 ## 1.3.0
 
 * Introduces the option to specify formatter line length in build.yaml.

--- a/widget_driver_generator/CHANGELOG.md
+++ b/widget_driver_generator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.3.3
 
-* Introduces the option to specify formatter line length in build.yaml.
+* Remove unnecessary '= null' from property code generation
 
 ## 1.3.0
 

--- a/widget_driver_generator/lib/src/code_providers/test_driver_code_provider.dart
+++ b/widget_driver_generator/lib/src/code_providers/test_driver_code_provider.dart
@@ -72,9 +72,10 @@ class $_testDriverClassName extends TestDriver implements $_driverClassName {
   /// In this example, then the `bool myStoredProperty` would be
   /// the `propertyDefinition` and the `false` would be the returnValue.
   String _getStoredPropertyCode(String propertyDefinition, String returnValue) {
+    final returnCode = returnValue == "null" ? "" : " = $returnValue";
     String sourceCode = '''
 @override
-$propertyDefinition = $returnValue;''';
+$propertyDefinition$returnCode;''';
     return sourceCode;
   }
 

--- a/widget_driver_generator/pubspec.yaml
+++ b/widget_driver_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widget_driver_generator
 description: This package provides generators for WidgetDriver to automate the creation of your TestDrivers and WidgetDriverProviders
-version: 1.3.0
+version: 1.3.3
 repository: https://github.com/bmw-tech/widget_driver/tree/master/widget_driver_generator
 issue_tracker: https://github.com/bmw-tech/widget_driver/issues
 


### PR DESCRIPTION
## Description
This fixes https://github.com/bmw-tech/widget_driver/issues/166

```
final MyClass? class = MyClass();
```
until now produced:
```
@override
final MyClass? class = null;
```
This produces:
```
@override
final MyClass? class;
```

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
