### PR TITLE
Refactor GitHub Actions workflows for consistency and clarity, and use fixed versions based on commit hash

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -1,9 +1,9 @@
 name: check-code-quality
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
     types: ["labeled", "opened", "synchronize", "reopened"]
 
 jobs:
@@ -17,12 +17,14 @@ jobs:
           echo "please set the label 'ready for pipeline' to start the pipeline"
           failure()
       - name: Checkout the latest code
-        uses: actions/checkout@v2
-      - name: prepare flutter
-        uses: subosito/flutter-action@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepare flutter
+        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # v2.19.0
         with:
-          flutter-version: '3.10.0'
-          channel: 'stable'
+          flutter-version: "3.10.0"
+          channel: "stable"
+
       - name: Run quality checks if pipeline label was set
         run: |
           git config --global --add safe.directory /opt/hostedtoolcache/flutter/stable-3.10.0-x64

--- a/.github/workflows/publish_all_packages.yml
+++ b/.github/workflows/publish_all_packages.yml
@@ -10,7 +10,10 @@ jobs:
       id-token: write # Required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dart-lang/setup-dart@v1
+      - name: Checkout the latest code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+
       - name: Publish packages
         run: bash scripts/run-publish.sh


### PR DESCRIPTION
## Description
Instead of just using the tag to reference which GitHub action to use, we are pinning it to a specific commit hash for that version. Makes it a bit safer. Also updating the actions to use the latest available version

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [x] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
