### PR TITLE
Update create-git-tags-for-publishing.yml to checkout the code first

### DIFF
--- a/.github/workflows/create-git-tags-for-publishing.yml
+++ b/.github/workflows/create-git-tags-for-publishing.yml
@@ -7,5 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create git tag for each package in the repo
         run: bash scripts/run-tag-release.sh


### PR DESCRIPTION
## Description

Missed the part that github action has to first checkout the code

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [x] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
